### PR TITLE
Add reusable Keycloak component

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ arkit8s/
 └── base/
 ```
 
+
+## 🔁 Shared Components
+
+Reusable building blocks shared across domains. Components like `shared-components/keycloak` provide ready-to-use manifests with environment overlays.
+
+### Example usage
+
+```yaml
+resources:
+  - ../../shared-components/keycloak/overlays/dev
+```
+
 ## 📌 Example Annotation and Dependency
 
 ```yaml

--- a/shared-components/keycloak/base/deployment.yaml
+++ b/shared-components/keycloak/base/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:24.0.4
+          args: ["start-dev"]
+          env:
+            - name: KEYCLOAK_ADMIN
+              value: admin
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              value: admin
+            - name: KC_DB
+              value: dev-mem
+          ports:
+            - containerPort: 8080

--- a/shared-components/keycloak/base/kustomization.yaml
+++ b/shared-components/keycloak/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/shared-components/keycloak/base/service.yaml
+++ b/shared-components/keycloak/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+spec:
+  selector:
+    app: keycloak
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/shared-components/keycloak/overlays/dev/kustomization.yaml
+++ b/shared-components/keycloak/overlays/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ../../base
+
+patchesStrategicMerge:
+  - patch-deployment.yaml

--- a/shared-components/keycloak/overlays/dev/patch-deployment.yaml
+++ b/shared-components/keycloak/overlays/dev/patch-deployment.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+spec:
+  template:
+    spec:
+      containers:
+        - name: keycloak
+          env:
+            - name: KC_HEALTH_ENABLED
+              value: "true"

--- a/shared-components/keycloak/overlays/prod/kustomization.yaml
+++ b/shared-components/keycloak/overlays/prod/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ../../base
+
+patchesStrategicMerge:
+  - patch-deployment.yaml

--- a/shared-components/keycloak/overlays/prod/patch-deployment.yaml
+++ b/shared-components/keycloak/overlays/prod/patch-deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: keycloak
+          env:
+            - name: KC_HEALTH_ENABLED
+              value: "true"

--- a/support-domain/auth/kustomization.yaml
+++ b/support-domain/auth/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../../shared-components/keycloak/overlays/dev


### PR DESCRIPTION
## Summary
- add reusable Keycloak component with base manifests
- create dev and prod overlays with deployment patches
- wire Keycloak into an example support-domain
- document shared components in README

## Testing
- `kustomize version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861639465e48333b4ddd762e4c23d4a