### PR TITLE
Create identity verification placeholder

### DIFF
--- a/business-domain/company-management/identity-verification/kustomization.yaml
+++ b/business-domain/company-management/identity-verification/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../../../components/identity-verification/overlays/dev

--- a/business-domain/person-management/identity-verification/kustomization.yaml
+++ b/business-domain/person-management/identity-verification/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../../../components/identity-verification/overlays/dev

--- a/components/identity-verification/base/deployment.yaml
+++ b/components/identity-verification/base/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity-verification
+  labels:
+    app: identity-verification
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: identity-verification
+  template:
+    metadata:
+      labels:
+        app: identity-verification
+    spec:
+      containers:
+        - name: identity-verification
+          image: busybox:1.36
+          command: ["sh", "-c", "sleep infinity"]

--- a/components/identity-verification/base/kustomization.yaml
+++ b/components/identity-verification/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/components/identity-verification/base/service.yaml
+++ b/components/identity-verification/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity-verification
+spec:
+  selector:
+    app: identity-verification
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/components/identity-verification/overlays/dev/kustomization.yaml
+++ b/components/identity-verification/overlays/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ../../base
+
+patchesStrategicMerge:
+  - patch-deployment.yaml

--- a/components/identity-verification/overlays/dev/patch-deployment.yaml
+++ b/components/identity-verification/overlays/dev/patch-deployment.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity-verification
+spec:
+  template:
+    spec:
+      containers:
+        - name: identity-verification
+          env:
+            - name: PLACEHOLDER_ENV
+              value: "dev"

--- a/components/identity-verification/overlays/prod/kustomization.yaml
+++ b/components/identity-verification/overlays/prod/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ../../base
+
+patchesStrategicMerge:
+  - patch-deployment.yaml

--- a/components/identity-verification/overlays/prod/patch-deployment.yaml
+++ b/components/identity-verification/overlays/prod/patch-deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity-verification
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: identity-verification
+          env:
+            - name: PLACEHOLDER_ENV
+              value: "prod"

--- a/support-domain/address-validator/kustomization.yaml
+++ b/support-domain/address-validator/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../../components/identity-verification/overlays/dev

--- a/support-domain/user-profile/kustomization.yaml
+++ b/support-domain/user-profile/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../../components/identity-verification/overlays/dev


### PR DESCRIPTION
## Summary
- add identity verification component with base and dev/prod overlays
- wire identity-verification into new business and support-domain folders

## Testing
- `kustomize build business-domain/person-management/identity-verification`
- `kustomize build components/identity-verification/overlays/prod`
- `kustomize build support-domain/user-profile`

------
https://chatgpt.com/codex/tasks/task_e_6861661f2cf48333ae42c83b71ab68f5