### PR TITLE
Integrate Keycloak shared component

### DIFF
--- a/shared-components/access-control/keycloak/base/deployment.yaml
+++ b/shared-components/access-control/keycloak/base/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+  annotations:
+    domain.type: "support"
+    component.shared: "true"
+    component.name: "keycloak"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:24.0.4
+          args: ["start-dev"]
+          env:
+            - name: KEYCLOAK_ADMIN
+              value: admin
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              value: admin
+            - name: KC_DB
+              value: dev-mem
+          ports:
+            - containerPort: 8080

--- a/shared-components/access-control/keycloak/base/kustomization.yaml
+++ b/shared-components/access-control/keycloak/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/shared-components/access-control/keycloak/base/service.yaml
+++ b/shared-components/access-control/keycloak/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+spec:
+  selector:
+    app: keycloak
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/shared-components/access-control/keycloak/overlays/dev/kustomization.yaml
+++ b/shared-components/access-control/keycloak/overlays/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ../../base
+
+patchesStrategicMerge:
+  - patch-deployment.yaml

--- a/shared-components/access-control/keycloak/overlays/dev/patch-deployment.yaml
+++ b/shared-components/access-control/keycloak/overlays/dev/patch-deployment.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+spec:
+  template:
+    spec:
+      containers:
+        - name: keycloak
+          env:
+            - name: KC_HEALTH_ENABLED
+              value: "true"

--- a/shared-components/access-control/keycloak/overlays/prod/kustomization.yaml
+++ b/shared-components/access-control/keycloak/overlays/prod/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../../base

--- a/support-domain/auth/kustomization.yaml
+++ b/support-domain/auth/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-  - ../../shared-components/keycloak/overlays/dev
+  - ../../shared-components/access-control/keycloak/overlays/dev


### PR DESCRIPTION
## Summary
- add Keycloak shared component under `shared-components/access-control`
- create dev overlay with health check env var
- create prod overlay placeholder
- reference the component from `support-domain/auth`

## Testing
- `git status --short`
- *(failed: `kustomize build support-domain/auth` - `kustomize: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686166cc8a3c8333bb7543878b81387c