### PR TITLE
Update image references to RHEL9 base

### DIFF
--- a/business-domain/company-management/identity-verification/deployment.yaml
+++ b/business-domain/company-management/identity-verification/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: identity-verification
-          image: registry.redhat.io/openshift4/ose-tools-rhel
+          image: registry.redhat.io/openshift4/ose-tools-rhel9
           command:
             - /bin/bash
             - -c

--- a/business-domain/person-management/identity-verification/deployment.yaml
+++ b/business-domain/person-management/identity-verification/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: identity-verification
-          image: registry.redhat.io/openshift4/ose-tools-rhel
+          image: registry.redhat.io/openshift4/ose-tools-rhel9
           command:
             - /bin/bash
             - -c

--- a/support-domain/address-validator/deployment.yaml
+++ b/support-domain/address-validator/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: identity-verification
-          image: registry.redhat.io/openshift4/ose-tools-rhel
+          image: registry.redhat.io/openshift4/ose-tools-rhel9
           command:
             - /bin/bash
             - -c

--- a/support-domain/user-profile/deployment.yaml
+++ b/support-domain/user-profile/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: identity-verification
-          image: registry.redhat.io/openshift4/ose-tools-rhel
+          image: registry.redhat.io/openshift4/ose-tools-rhel9
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
## Summary
- use `registry.redhat.io/openshift4/ose-tools-rhel9` base image in domain deployments

## Testing
- `./validate-cluster.sh` *(fails: `Namespace business-domain no existe`)*

------
https://chatgpt.com/codex/tasks/task_e_68618260b00c8333a3e1fe1e9e498ed3