### PR TITLE
Add GitOps helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This project aims to:
 
 ## 💻 Manual GitOps
 
-Follow these commands to deploy or reset the full stack without a GitOps operator.
+Use the helper scripts below to deploy or reset the full stack without a GitOps operator.
 
 ### 🧱 Bootstrap (crear namespaces)
 
@@ -106,6 +106,27 @@ oc apply -f bootstrap/
 
 ```bash
 oc apply -f . --recursive
+```
+
+### 🚀 Instalación rápida
+
+```bash
+./gitops-install.sh  # para Linux/macOS
+./gitops-install.ps1 # para PowerShell
+```
+
+### 🧹 Desinstalación rápida
+
+```bash
+./gitops-uninstall.sh  # para Linux/macOS
+./gitops-uninstall.ps1 # para PowerShell
+```
+
+### 👀 Observación continua
+
+```bash
+./watch-cluster.sh      # por defecto 5 minutos
+./watch-cluster.ps1 10  # observar por 10 minutos
 ```
 
 ### 🧹 Limpiar entorno (opcional)

--- a/gitops-install.ps1
+++ b/gitops-install.ps1
@@ -1,0 +1,11 @@
+Write-Host "\nApplying bootstrap namespaces..."
+oc apply -f bootstrap/
+
+Write-Host "\nSynchronizing repository manifests..."
+oc apply -f . --recursive
+
+Write-Host "\nRunning validation..."
+& ./validate-cluster.ps1
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "\nInstall completed successfully."

--- a/gitops-install.sh
+++ b/gitops-install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+printf '\n📦 Applying bootstrap namespaces...\n'
+oc apply -f "$REPO_ROOT/bootstrap/"
+
+printf '\n🔄 Synchronizing repository manifests...\n'
+oc apply -f "$REPO_ROOT" --recursive
+
+printf '\n✅ Running validation...\n'
+"$REPO_ROOT/validate-cluster.sh"
+
+printf '\n🎉 Install completed successfully.\n'

--- a/gitops-uninstall.ps1
+++ b/gitops-uninstall.ps1
@@ -1,0 +1,7 @@
+Write-Host "\nDeleting manifests..."
+oc delete -f . --recursive | Out-Null
+
+Write-Host "\nDeleting bootstrap namespaces..."
+oc delete -f bootstrap/ | Out-Null
+
+Write-Host "\nCleanup completed."

--- a/gitops-uninstall.sh
+++ b/gitops-uninstall.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+printf '\n🗑️ Deleting manifests...\n'
+oc delete -f "$REPO_ROOT" --recursive || true
+
+printf '\n🗑️ Deleting bootstrap namespaces...\n'
+oc delete -f "$REPO_ROOT/bootstrap/" || true
+
+printf '\nCleanup completed.\n'

--- a/watch-cluster.ps1
+++ b/watch-cluster.ps1
@@ -1,0 +1,26 @@
+param(
+    [int]$Minutes = 5
+)
+
+Write-Host "Watching cluster for $Minutes minute(s)..."
+$end = (Get-Date).AddMinutes($Minutes)
+$ok = $true
+
+while ((Get-Date) -lt $end) {
+    & ./validate-cluster.ps1 > $null 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "$(Get-Date): OK"
+    } else {
+        Write-Host "$(Get-Date): MISMATCH"
+        $ok = $false
+    }
+    Start-Sleep -Seconds 30
+}
+
+if ($ok) {
+    Write-Host "Cluster remained in sync during watch period."
+    exit 0
+} else {
+    Write-Error "Issues detected while watching cluster."
+    exit 1
+}

--- a/watch-cluster.sh
+++ b/watch-cluster.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+DURATION_MINUTES="${1:-5}"
+end=$((SECONDS + DURATION_MINUTES * 60))
+result=0
+
+printf '🔎 Watching cluster for %s minute(s)...\n' "$DURATION_MINUTES"
+
+while [ $SECONDS -lt $end ]; do
+  if ./validate-cluster.sh >/dev/null 2>&1; then
+    printf '%s: ✅ cluster in sync\n' "$(date)"
+  else
+    printf '%s: ❌ cluster out of sync\n' "$(date)"
+    result=1
+  fi
+  sleep 30
+done
+
+if [ $result -eq 0 ]; then
+  printf '✅ Cluster remained in sync during watch period.\n'
+else
+  printf '⚠️  Issues detected while watching cluster.\n'
+fi
+exit $result


### PR DESCRIPTION
## Summary
- add install/uninstall scripts to mimic GitOps with `oc`
- add watch scripts for continuous validation
- document new helper scripts in README

## Testing
- `shellcheck gitops-install.sh gitops-uninstall.sh watch-cluster.sh`


------
https://chatgpt.com/codex/tasks/task_e_68618576c2908333bffe196d7f05ed37