### PR TITLE
Add status reporting to watch utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ oc apply -f architecture/ --recursive
 ./utilities/watch-cluster.sh 10 detailed    # 10 minutos con detalle medio
 ./utilities/watch-cluster.ps1 10 all        # usar PowerShell con detalle maximo
 ```
-En modo `detailed` se listan los namespaces, deployments y manifiestos de bootstrap en cada iteración.
+En modo `detailed` o `all` se listan los namespaces, deployments, manifiestos de bootstrap
+y se muestran los estados actuales de namespaces, deployments y pods en cada iteración.
 
 ### 🧹 Limpiar entorno (opcional)
 

--- a/utilities/watch-cluster.ps1
+++ b/utilities/watch-cluster.ps1
@@ -24,6 +24,15 @@ function Show-DetailedInfo {
         }
     }
 
+    Write-Host "Namespace status:"
+    oc get ns --no-headers | ForEach-Object { Write-Host "  $_" }
+
+    Write-Host "Deployment status:"
+    oc get deploy -A --no-headers | ForEach-Object { Write-Host "  $_" }
+
+    Write-Host "Pod status:"
+    oc get pods -A --no-headers | ForEach-Object { Write-Host "  $_" }
+
     Write-Host "Bootstrap manifests:"
     Get-ChildItem -Path $BootstrapDir -Filter '*.yaml' | ForEach-Object {
         Write-Host "  - $($_.Name)"

--- a/utilities/watch-cluster.sh
+++ b/utilities/watch-cluster.sh
@@ -23,6 +23,15 @@ show_detailed_info() {
       sed "s/^/  $ns\//"
   done
 
+  printf 'Namespace status:\n'
+  oc get ns --no-headers 2>/dev/null | sed 's/^/  /'
+
+  printf 'Deployment status:\n'
+  oc get deploy -A --no-headers 2>/dev/null | sed 's/^/  /'
+
+  printf 'Pod status:\n'
+  oc get pods -A --no-headers 2>/dev/null | sed 's/^/  /'
+
   printf 'Bootstrap manifests:\n'
   for f in "$BOOTSTRAP_DIR"/*.yaml; do
     printf '  - %s\n' "$(basename "$f")"


### PR DESCRIPTION
## Summary
- show namespace, deployment and pod status during watch
- mention new output in readme

## Testing
- `shellcheck utilities/watch-cluster.sh`
- `shellcheck utilities/validate-cluster.sh`
- `bash utilities/watch-cluster.sh 0 default`
- `bash utilities/watch-cluster.sh 0 detailed`

------
https://chatgpt.com/codex/tasks/task_e_686193613a788333b1822c17f4e436b2