### PR TITLE
Fix watch scripts to limit output to bootstrap namespaces

### DIFF
--- a/utilities/watch-cluster.ps1
+++ b/utilities/watch-cluster.ps1
@@ -25,13 +25,19 @@ function Show-DetailedInfo {
     }
 
     Write-Host "Namespace status:"
-    oc get ns --no-headers | ForEach-Object { Write-Host "  $_" }
+    foreach ($ns in $namespaces) {
+        oc get ns $ns --no-headers | ForEach-Object { Write-Host "  $_" }
+    }
 
     Write-Host "Deployment status:"
-    oc get deploy -A --no-headers | ForEach-Object { Write-Host "  $_" }
+    foreach ($ns in $namespaces) {
+        oc get deploy -n $ns --no-headers | ForEach-Object { Write-Host "  $ns/$_" }
+    }
 
     Write-Host "Pod status:"
-    oc get pods -A --no-headers | ForEach-Object { Write-Host "  $_" }
+    foreach ($ns in $namespaces) {
+        oc get pods -n $ns --no-headers | ForEach-Object { Write-Host "  $ns/$_" }
+    }
 
     Write-Host "Bootstrap manifests:"
     Get-ChildItem -Path $BootstrapDir -Filter '*.yaml' | ForEach-Object {

--- a/utilities/watch-cluster.sh
+++ b/utilities/watch-cluster.sh
@@ -24,13 +24,19 @@ show_detailed_info() {
   done
 
   printf 'Namespace status:\n'
-  oc get ns --no-headers 2>/dev/null | sed 's/^/  /'
+  for ns in "${namespaces[@]}"; do
+    oc get ns "$ns" --no-headers 2>/dev/null | sed 's/^/  /'
+  done
 
   printf 'Deployment status:\n'
-  oc get deploy -A --no-headers 2>/dev/null | sed 's/^/  /'
+  for ns in "${namespaces[@]}"; do
+    oc get deploy -n "$ns" --no-headers 2>/dev/null | sed "s/^/  $ns\//"
+  done
 
   printf 'Pod status:\n'
-  oc get pods -A --no-headers 2>/dev/null | sed 's/^/  /'
+  for ns in "${namespaces[@]}"; do
+    oc get pods -n "$ns" --no-headers 2>/dev/null | sed "s/^/  $ns\//"
+  done
 
   printf 'Bootstrap manifests:\n'
   for f in "$BOOTSTRAP_DIR"/*.yaml; do


### PR DESCRIPTION
## Summary
- restrict `watch-cluster.sh` to report namespace, deployment and pod status only for namespaces declared in `architecture/bootstrap`
- apply the same logic in `watch-cluster.ps1`

## Testing
- `shellcheck utilities/watch-cluster.sh`

------
https://chatgpt.com/codex/tasks/task_e_686194dc50d88333a820b10d30414485