### PR TITLE
Add base deployments for reference layers

### DIFF
--- a/architecture/business-domain/company-management/identity-verification/service.yaml
+++ b/architecture/business-domain/company-management/identity-verification/service.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: identity-verification
+  name: identity-verification-app-instance
   namespace: business-domain
 spec:
   selector:
-    app: identity-verification
+    app: identity-verification-app-instance
   ports:
     - protocol: TCP
       port: 80

--- a/architecture/business-domain/person-management/identity-verification/deployment.yaml
+++ b/architecture/business-domain/person-management/identity-verification/deployment.yaml
@@ -2,22 +2,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: identity-verification
+  name: identity-verification-app-instance
   labels:
-    app: identity-verification
+    app: identity-verification-app-instance
   namespace: business-domain
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: identity-verification
+      app: identity-verification-app-instance
   template:
     metadata:
       labels:
-        app: identity-verification
+        app: identity-verification-app-instance
     spec:
       containers:
-        - name: identity-verification
+        - name: identity-verification-app-instance
           image: registry.redhat.io/openshift4/ose-tools-rhel9
           command:
             - /bin/bash

--- a/architecture/business-domain/person-management/identity-verification/service.yaml
+++ b/architecture/business-domain/person-management/identity-verification/service.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: identity-verification
+  name: identity-verification-app-instance
   namespace: business-domain
 spec:
   selector:
-    app: identity-verification
+    app: identity-verification-app-instance
   ports:
     - protocol: TCP
       port: 80

--- a/architecture/deployment-access-control.yaml
+++ b/architecture/deployment-access-control.yaml
@@ -2,22 +2,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: identity-verification-app-instance
+  name: access-control-app-instance
   labels:
-    app: identity-verification-app-instance
-  namespace: business-domain
+    app: access-control-app-instance
+  namespace: shared-components
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: identity-verification-app-instance
+      app: access-control-app-instance
   template:
     metadata:
       labels:
-        app: identity-verification-app-instance
+        app: access-control-app-instance
     spec:
       containers:
-        - name: identity-verification-app-instance
+        - name: access-control-app-instance
           image: registry.redhat.io/openshift4/ose-tools-rhel9
           command:
             - /bin/bash

--- a/architecture/deployment-api.yaml
+++ b/architecture/deployment-api.yaml
@@ -2,22 +2,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: identity-verification-app-instance
+  name: api-app-instance
   labels:
-    app: identity-verification-app-instance
+    app: api-app-instance
   namespace: business-domain
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: identity-verification-app-instance
+      app: api-app-instance
   template:
     metadata:
       labels:
-        app: identity-verification-app-instance
+        app: api-app-instance
     spec:
       containers:
-        - name: identity-verification-app-instance
+        - name: api-app-instance
           image: registry.redhat.io/openshift4/ose-tools-rhel9
           command:
             - /bin/bash

--- a/architecture/deployment-data-access.yaml
+++ b/architecture/deployment-data-access.yaml
@@ -2,22 +2,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: identity-verification-app-instance
+  name: data-access-app-instance
   labels:
-    app: identity-verification-app-instance
-  namespace: business-domain
+    app: data-access-app-instance
+  namespace: support-domain
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: identity-verification-app-instance
+      app: data-access-app-instance
   template:
     metadata:
       labels:
-        app: identity-verification-app-instance
+        app: data-access-app-instance
     spec:
       containers:
-        - name: identity-verification-app-instance
+        - name: data-access-app-instance
           image: registry.redhat.io/openshift4/ose-tools-rhel9
           command:
             - /bin/bash

--- a/architecture/deployment-notification-external-services.yaml
+++ b/architecture/deployment-notification-external-services.yaml
@@ -2,22 +2,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: identity-verification-app-instance
+  name: notification-external-services-app-instance
   labels:
-    app: identity-verification-app-instance
-  namespace: business-domain
+    app: notification-external-services-app-instance
+  namespace: support-domain
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: identity-verification-app-instance
+      app: notification-external-services-app-instance
   template:
     metadata:
       labels:
-        app: identity-verification-app-instance
+        app: notification-external-services-app-instance
     spec:
       containers:
-        - name: identity-verification-app-instance
+        - name: notification-external-services-app-instance
           image: registry.redhat.io/openshift4/ose-tools-rhel9
           command:
             - /bin/bash

--- a/architecture/deployment-orchestrator.yaml
+++ b/architecture/deployment-orchestrator.yaml
@@ -2,22 +2,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: identity-verification-app-instance
+  name: orchestrator-app-instance
   labels:
-    app: identity-verification-app-instance
-  namespace: business-domain
+    app: orchestrator-app-instance
+  namespace: support-domain
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: identity-verification-app-instance
+      app: orchestrator-app-instance
   template:
     metadata:
       labels:
-        app: identity-verification-app-instance
+        app: orchestrator-app-instance
     spec:
       containers:
-        - name: identity-verification-app-instance
+        - name: orchestrator-app-instance
           image: registry.redhat.io/openshift4/ose-tools-rhel9
           command:
             - /bin/bash

--- a/architecture/deployment-ui.yaml
+++ b/architecture/deployment-ui.yaml
@@ -2,22 +2,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: identity-verification-app-instance
+  name: ui-app-instance
   labels:
-    app: identity-verification-app-instance
+    app: ui-app-instance
   namespace: business-domain
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: identity-verification-app-instance
+      app: ui-app-instance
   template:
     metadata:
       labels:
-        app: identity-verification-app-instance
+        app: ui-app-instance
     spec:
       containers:
-        - name: identity-verification-app-instance
+        - name: ui-app-instance
           image: registry.redhat.io/openshift4/ose-tools-rhel9
           command:
             - /bin/bash

--- a/architecture/support-domain/address-validator/deployment.yaml
+++ b/architecture/support-domain/address-validator/deployment.yaml
@@ -2,22 +2,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: identity-verification
+  name: identity-verification-app-instance
   labels:
-    app: identity-verification
+    app: identity-verification-app-instance
   namespace: support-domain
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: identity-verification
+      app: identity-verification-app-instance
   template:
     metadata:
       labels:
-        app: identity-verification
+        app: identity-verification-app-instance
     spec:
       containers:
-        - name: identity-verification
+        - name: identity-verification-app-instance
           image: registry.redhat.io/openshift4/ose-tools-rhel9
           command:
             - /bin/bash

--- a/architecture/support-domain/address-validator/service.yaml
+++ b/architecture/support-domain/address-validator/service.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: identity-verification
+  name: identity-verification-app-instance
   namespace: support-domain
 spec:
   selector:
-    app: identity-verification
+    app: identity-verification-app-instance
   ports:
     - protocol: TCP
       port: 80

--- a/architecture/support-domain/user-profile/deployment.yaml
+++ b/architecture/support-domain/user-profile/deployment.yaml
@@ -2,22 +2,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: identity-verification
+  name: identity-verification-app-instance
   labels:
-    app: identity-verification
+    app: identity-verification-app-instance
   namespace: support-domain
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: identity-verification
+      app: identity-verification-app-instance
   template:
     metadata:
       labels:
-        app: identity-verification
+        app: identity-verification-app-instance
     spec:
       containers:
-        - name: identity-verification
+        - name: identity-verification-app-instance
           image: registry.redhat.io/openshift4/ose-tools-rhel9
           command:
             - /bin/bash

--- a/architecture/support-domain/user-profile/service.yaml
+++ b/architecture/support-domain/user-profile/service.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: identity-verification
+  name: identity-verification-app-instance
   namespace: support-domain
 spec:
   selector:
-    app: identity-verification
+    app: identity-verification-app-instance
   ports:
     - protocol: TCP
       port: 80


### PR DESCRIPTION
## Summary
- add initial Deployment placeholders for UI, API, orchestrator, access-control, data-access and notification-external-services
- rename sample components with `app-instance` suffix

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861a0a3bd38833382ad9125d0980e73