### PR TITLE
Fix Keycloak deployment YAML

### DIFF
--- a/architecture/shared-components/access-control/keycloak/deployment.yaml
+++ b/architecture/shared-components/access-control/keycloak/deployment.yaml
@@ -9,11 +9,11 @@ metadata:
     domain.type: support
     component.shared: 'true'
     component.name: keycloak
-      architecture.domain: shared
-      architecture.function: auth-provider
-      architecture.invoked_by: access-control-app-instance
-      architecture.calls: user-database
-      architecture.part_of: arkit8s
+    architecture.domain: shared
+    architecture.function: auth-provider
+    architecture.invoked_by: access-control-app-instance
+    architecture.calls: user-database
+    architecture.part_of: arkit8s
   namespace: shared-components
 spec:
   replicas: 1


### PR DESCRIPTION
## Summary
- fix annotation indentation in Keycloak deployment

## Testing
- `python3 - <<'PY'
import yaml
yaml.safe_load(open('architecture/shared-components/access-control/keycloak/deployment.yaml'))
print('OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6861d6a17bd88333a328676758761d41