### PR TITLE
Use built-in kustomize via oc

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ oc apply -f architecture/bootstrap/
 ### 🚀 Despliegue completo
 
 ```bash
-kustomize build environments/sandbox | oc apply -f -
+oc apply -k environments/sandbox
 ```
 
 ### 🚀 Instalación rápida

--- a/utilities/gitops-install.ps1
+++ b/utilities/gitops-install.ps1
@@ -9,7 +9,7 @@ Write-Host "\nApplying bootstrap namespaces..."
 oc apply -f (Join-Path $ArchDir "bootstrap")
 
 Write-Host "\nSynchronizing repository manifests for $Environment..."
-kustomize build $EnvDir | oc apply -f -
+oc apply -k $EnvDir
 
 Write-Host "\nRunning validation..."
 & (Join-Path $ScriptDir "validate-cluster.ps1") $Environment

--- a/utilities/gitops-install.sh
+++ b/utilities/gitops-install.sh
@@ -11,7 +11,7 @@ printf '\n📦 Applying bootstrap namespaces...\n'
 oc apply -f "$ARCH_DIR/bootstrap/"
 
 printf '\n🔄 Synchronizing repository manifests for %s...\n' "$ENVIRONMENT"
-kustomize build "$ENV_DIR" | oc apply -f -
+oc apply -k "$ENV_DIR"
 
 printf '\n✅ Running validation...\n'
 "$SCRIPT_DIR/validate-cluster.sh" "$ENVIRONMENT"

--- a/utilities/validate-cluster.ps1
+++ b/utilities/validate-cluster.ps1
@@ -45,7 +45,7 @@ foreach ($ns in $namespaces) {
 }
 
 Write-Host "Verificando sincronización de manifiestos para $Environment..."
-$diff = kustomize build $EnvDir | oc diff -f - 2>&1
+$diff = oc diff -k $EnvDir 2>&1
 if ($LASTEXITCODE -ne 0) {
     if ($LASTEXITCODE -eq 1) {
         Write-Error "Manifiestos desincronizados:"

--- a/utilities/validate-cluster.sh
+++ b/utilities/validate-cluster.sh
@@ -49,7 +49,7 @@ for ns in "${NAMESPACES[@]}"; do
 done
 
 echo "🔄 Verificando sincronización de manifiestos para $ENVIRONMENT..."
-if ! kustomize build "$ENV_DIR" | oc diff -f - >/tmp/diff.txt 2>&1; then
+if ! oc diff -k "$ENV_DIR" >/tmp/diff.txt 2>&1; then
   status=$?
   if [ $status -eq 1 ]; then
     echo "Manifiestos desincronizados:" >&2


### PR DESCRIPTION
## Summary
- use `oc apply -k` and `oc diff -k`
- update helper scripts accordingly
- refresh README example

## Testing
- `shellcheck utilities/gitops-install.sh utilities/validate-cluster.sh`
- `sudo apt-get update`
- `sudo apt-get install -y shellcheck`

------
https://chatgpt.com/codex/tasks/task_e_68629f082db08333873236b17642eab7