### PR TITLE
Fix bootstrap install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Use the helper scripts below to deploy or reset the full stack without a GitOps 
 ### 🧱 Bootstrap (crear namespaces)
 
 ```bash
-oc apply -f architecture/bootstrap/
+oc apply -k architecture/bootstrap/
 ```
 
 ### 🚀 Despliegue completo

--- a/utilities/gitops-install.ps1
+++ b/utilities/gitops-install.ps1
@@ -6,7 +6,7 @@ if (-not $Environment) { $Environment = 'sandbox' }
 $EnvDir = Join-Path $RepoRoot "environments/$Environment"
 
 Write-Host "\nApplying bootstrap namespaces..."
-oc apply -f (Join-Path $ArchDir "bootstrap")
+oc apply -k (Join-Path $ArchDir "bootstrap")
 
 Write-Host "\nSynchronizing repository manifests for $Environment..."
 oc apply -k $EnvDir

--- a/utilities/gitops-install.sh
+++ b/utilities/gitops-install.sh
@@ -8,7 +8,7 @@ ENVIRONMENT="${1:-sandbox}"
 ENV_DIR="$REPO_ROOT/environments/$ENVIRONMENT"
 
 printf '\n📦 Applying bootstrap namespaces...\n'
-oc apply -f "$ARCH_DIR/bootstrap/"
+oc apply -k "$ARCH_DIR/bootstrap/"
 
 printf '\n🔄 Synchronizing repository manifests for %s...\n' "$ENVIRONMENT"
 oc apply -k "$ENV_DIR"


### PR DESCRIPTION
## Summary
- use `oc apply -k` when applying bootstrap manifests
- update install scripts and README accordingly

## Testing
- `python3 utilities/generate-architecture-report.py`

------
https://chatgpt.com/codex/tasks/task_e_6862a71537e0833397c87f71f9da5e97