### PR TITLE
Fix YAML validation without cluster

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,13 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install oc
-        uses: redhat-actions/oc-installer@v1
-        with:
-          version: 'stable'
-      - name: Login to cluster
-        if: env.OPENSHIFT_SERVER != '' && env.OPENSHIFT_TOKEN != ''
-        run: oc login "$OPENSHIFT_SERVER" --token "$OPENSHIFT_TOKEN" --insecure-skip-tls-verify
       - name: Run YAML validation
         run: |
           chmod +x utilities/validate-yaml.sh

--- a/README.md
+++ b/README.md
@@ -152,12 +152,10 @@ oc delete -f architecture/bootstrap/
 ```bash
 ./utilities/validate-yaml.sh
 ```
-El script ejecuta `oc apply --dry-run=client` sobre cada manifiesto para
-detectar errores de sintaxis o tipografía antes de realizar el despliegue o
-enviar un pull request. No es necesario iniciar sesión en el clúster para
-validar localmente. En GitHub Actions la validación se ejecuta automáticamente y
-si se definen las variables `OPENSHIFT_SERVER` y `OPENSHIFT_TOKEN` el workflow
-realizará `oc login` antes de validar.
+El script analiza cada archivo con **PyYAML** para detectar errores de sintaxis
+sin necesidad de tener configurado `oc` o un clúster disponible. Si la librería
+no está instalada se descargará automáticamente. En GitHub Actions la validación
+se ejecuta igual de forma autónoma y no depende de `oc login`.
 
 ### 📊 Reporte de arquitectura
 

--- a/utilities/validate-yaml.sh
+++ b/utilities/validate-yaml.sh
@@ -7,11 +7,28 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 printf '🔍 Validando manifiestos YAML...\n'
 
+# Ensure PyYAML is available for syntax validation
+if ! python3 - <<'EOF' >/dev/null 2>&1
+import yaml
+EOF
+then
+  python3 -m pip install --user --quiet pyyaml >/dev/null 2>&1
+fi
+
 mapfile -t yaml_files < <(find "$REPO_ROOT" -name '*.yaml' ! -name 'kustomization.yaml' | sort)
 status=0
 
 for file in "${yaml_files[@]}"; do
-  if oc apply --dry-run=client -f "$file" >/dev/null 2>&1; then
+  if python3 - <<EOF >/dev/null 2>&1
+import sys, yaml
+from pathlib import Path
+try:
+    with Path("$file").open('r') as f:
+        list(yaml.safe_load_all(f))
+except yaml.YAMLError:
+    sys.exit(1)
+EOF
+  then
     printf '✅ %s\n' "$file"
   else
     printf '❌ Error al validar %s\n' "$file" >&2


### PR DESCRIPTION
## Summary
- remove dependency on `oc` for YAML validation
- Python-based validation with PyYAML
- update README notes
- simplify GitHub Actions workflow

## Testing
- `utilities/validate-yaml.sh`


------
https://chatgpt.com/codex/tasks/task_e_6862e07cb6d483339fc154ff0ef21f17