### PR TITLE
Add global label for retrieving all manifests

### DIFF
--- a/architecture/bootstrap/kustomization.yaml
+++ b/architecture/bootstrap/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.domain: bootstrap
 resources:
   - 00-namespace-business-domain.yaml
   - 00-namespace-shared-components.yaml

--- a/architecture/business-domain/api/kustomization.yaml
+++ b/architecture/business-domain/api/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.component: api
 resources:
   - deployment.yaml

--- a/architecture/business-domain/company-management/identity-verification/kustomization.yaml
+++ b/architecture/business-domain/company-management/identity-verification/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.component: company-identity-verification
 resources:
   - deployment.yaml
   - service.yaml

--- a/architecture/business-domain/company-management/kustomization.yaml
+++ b/architecture/business-domain/company-management/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.domain: business
 resources:
   - identity-verification

--- a/architecture/business-domain/kustomization.yaml
+++ b/architecture/business-domain/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.domain: business
 resources:
   - api
   - company-management

--- a/architecture/business-domain/person-management/identity-verification/kustomization.yaml
+++ b/architecture/business-domain/person-management/identity-verification/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.component: person-identity-verification
 resources:
   - deployment.yaml
   - service.yaml

--- a/architecture/business-domain/person-management/kustomization.yaml
+++ b/architecture/business-domain/person-management/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.domain: business
 resources:
   - identity-verification

--- a/architecture/business-domain/ui/kustomization.yaml
+++ b/architecture/business-domain/ui/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.component: ui
 resources:
   - deployment.yaml

--- a/architecture/kustomization.yaml
+++ b/architecture/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.part_of: arkit8s
+  app-type: arkit8s
 resources:
   - bootstrap
   - business-domain

--- a/architecture/shared-components/access-control/access-control-app-instance/kustomization.yaml
+++ b/architecture/shared-components/access-control/access-control-app-instance/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.component: access-control
 resources:
   - deployment.yaml

--- a/architecture/shared-components/access-control/keycloak/kustomization.yaml
+++ b/architecture/shared-components/access-control/keycloak/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.component: auth-provider
 resources:
   - deployment.yaml
   - service.yaml

--- a/architecture/shared-components/access-control/kustomization.yaml
+++ b/architecture/shared-components/access-control/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.domain: shared
 resources:
   - keycloak
   - access-control-app-instance

--- a/architecture/shared-components/kustomization.yaml
+++ b/architecture/shared-components/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.domain: shared
 resources:
   - access-control

--- a/architecture/support-domain/address-validator/kustomization.yaml
+++ b/architecture/support-domain/address-validator/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.component: address-validator
 resources:
   - deployment.yaml
   - service.yaml

--- a/architecture/support-domain/data-access/kustomization.yaml
+++ b/architecture/support-domain/data-access/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.component: data-access
 resources:
   - deployment.yaml

--- a/architecture/support-domain/kustomization.yaml
+++ b/architecture/support-domain/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.domain: support
 resources:
   - address-validator
   - notification-external-services

--- a/architecture/support-domain/notification-external-services/kustomization.yaml
+++ b/architecture/support-domain/notification-external-services/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.component: notification
 resources:
   - deployment.yaml

--- a/architecture/support-domain/orchestrator/kustomization.yaml
+++ b/architecture/support-domain/orchestrator/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.component: orchestrator
 resources:
   - deployment.yaml

--- a/architecture/support-domain/user-profile/kustomization.yaml
+++ b/architecture/support-domain/user-profile/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  arkit8s.component: user-profile
 resources:
   - deployment.yaml
   - service.yaml


### PR DESCRIPTION
## Summary
- apply `app-type: arkit8s` label to the root kustomization

## Testing
- `python3 arkit8s.py validate-yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6863e6c93c6c833384cffcc1fcd2b63f