### PR TITLE
Add permission warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ This project aims to:
 
 Use the helper scripts below to deploy or reset the full stack without a GitOps operator.
 
+> ⚠️ **Advertencia**: asegúrate de ejecutar los comandos con una cuenta que tenga permisos para crear namespaces y aplicar recursos. La cuenta `developer` suele carecer de estos privilegios, por lo que podrías recibir errores *Forbidden*. Inicia sesión con un usuario con privilegios (por ejemplo, `oc login -u kubeadmin`) o solicita los permisos necesarios.
+
 ### 🧱 Bootstrap (crear namespaces)
 
 ```bash

--- a/arkit8s.py
+++ b/arkit8s.py
@@ -21,8 +21,15 @@ def run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
 
 def install(args: argparse.Namespace) -> int:
     env = args.env
-    run(["oc", "apply", "-k", str(ARCH_DIR / "bootstrap")])
-    run(["oc", "apply", "-k", str(ENV_DIR / env)])
+    try:
+        run(["oc", "apply", "-k", str(ARCH_DIR / "bootstrap")])
+        run(["oc", "apply", "-k", str(ENV_DIR / env)])
+    except subprocess.CalledProcessError:
+        print(
+            "\u26a0\ufe0f  Verifica que la cuenta tenga permisos para crear namespaces y aplicar recursos",
+            file=sys.stderr,
+        )
+        return 1
     return validate_cluster(args)
 
 


### PR DESCRIPTION
## Summary
- mention required permissions in manual GitOps docs
- show warning when `install` fails due to missing privileges

## Testing
- `python3 -m py_compile arkit8s.py`
- `python3 arkit8s.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6863fac1fce08333b2a9fc69c266dc8c