### PR TITLE
fix: use tabs for make recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ HOST=http://rhbk.apps-crc.testing/
 .PHONY: crc-dev wait admin open destroy
 
 crc-dev:
-        oc kustomize bootstrap/operators/rhbk --load-restrictor=LoadRestrictionsNone | oc apply -f -
-        @echo "Waiting for RHBK operator to be ready..."
-        @oc wait --for=condition=Succeeded -n $(NAMESPACE) csv -l operators.coreos.com/rhbk-operator.$(NAMESPACE) --timeout=300s
-        oc apply -k support-domain/identity
+	oc kustomize bootstrap/operators/rhbk --load-restrictor=LoadRestrictionsNone | oc apply -f -
+	@echo "Waiting for RHBK operator to be ready..."
+	@oc wait --for=condition=Succeeded -n $(NAMESPACE) csv -l operators.coreos.com/rhbk-operator.$(NAMESPACE) --timeout=300s
+	oc apply -k support-domain/identity
 
 wait:
 	@echo "Waiting for Keycloak to be ready..."
@@ -21,5 +21,5 @@ open:
 	@echo $(HOST)
 
 destroy:
-        -oc delete -k support-domain/identity
-        -oc kustomize bootstrap/operators/rhbk --load-restrictor=LoadRestrictionsNone | oc delete -f -
+	-oc delete -k support-domain/identity
+	-oc kustomize bootstrap/operators/rhbk --load-restrictor=LoadRestrictionsNone | oc delete -f -


### PR DESCRIPTION
## Summary
- fix makefile indentation using tabs for command recipes

## Testing
- `make -n crc-dev`
- `make -n wait`
- `make -n admin`
- `make -n open`
- `make -n destroy`


------
https://chatgpt.com/codex/tasks/task_e_68af3cc9c5388333a31ab1499e6c51a3