### PR TITLE
Specify bash shell in Makefile for Windows compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /usr/bin/bash
+
 NAMESPACE=rhbk
 HOST=http://rhbk.apps-crc.testing/
 


### PR DESCRIPTION
## Summary
- Ensure Makefile uses bash to avoid Windows path errors

## Testing
- `make open`


------
https://chatgpt.com/codex/tasks/task_e_68af46d2de248333a85e89ccdaf6e685