### PR TITLE
fix: makefile shell path cross-platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /usr/bin/bash
+SHELL := bash
 
 NAMESPACE=rhbk
 HOST=http://rhbk.apps-crc.testing/


### PR DESCRIPTION
## Summary
- use Bash from PATH instead of hardcoded /usr/bin/bash in Makefile

## Testing
- `make -n crc-dev`


------
https://chatgpt.com/codex/tasks/task_e_68af5d747c80833385f182ef7de62f06