### PR TITLE
Add Kubernetes manifests for sentik component

### DIFF
--- a/architecture/support-domain/kustomization.yaml
+++ b/architecture/support-domain/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - data-access
   - orchestrator
   - user-profile
+  - sentik

--- a/architecture/support-domain/sentik/configmap.yaml
+++ b/architecture/support-domain/sentik/configmap.yaml
@@ -1,0 +1,177 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sentik-send-not-ready-script
+  namespace: support-domain
+  labels:
+    app: sentik
+  annotations:
+    architecture.domain: support
+    architecture.function: sentik
+    architecture.part_of: arkit8s
+data:
+  run.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    timestamp() {
+      date -u +"%Y-%m-%dT%H:%M:%SZ"
+    }
+
+    log() {
+      echo "[$(timestamp)] $1"
+    }
+
+    log "+++ starting sentik send-not-ready script +++"
+
+    TEAMS_WEBHOOK_URL="${TEAMS_WEBHOOK_URL:-}"
+    FRONTEND_URL="${FRONTEND_URL:-}"
+
+    if [ -z "$TEAMS_WEBHOOK_URL" ]; then
+      log "ERROR: TEAMS_WEBHOOK_URL is not set"
+      exit 1
+    fi
+    if [ -z "$FRONTEND_URL" ]; then
+      log "ERROR: FRONTEND_URL is not set"
+      exit 1
+    fi
+
+    now_ts="$(timestamp)"
+    log "timestamp: $now_ts"
+
+    namespaces="$(oc projects -q 2>/dev/null || true)"
+    log "namespaces detected: [$namespaces]"
+    if [ -z "$namespaces" ]; then
+      log "no namespaces available. exiting without error."
+      exit 0
+    fi
+
+    csv_file="/tmp/not_ready_resources.csv"
+    if ! echo "namespace,resource,type,timestamp" > "$csv_file"; then
+      mkdir -p "$HOME/tmp"
+      csv_file="$HOME/tmp/not_ready_resources.csv"
+      echo "namespace,resource,type,timestamp" > "$csv_file"
+    fi
+    log "csv header written to $csv_file"
+
+    deploy_total=0
+    deploy_not_ready=0
+    dc_total=0
+    dc_not_ready=0
+    ns_with_issues=0
+
+    for ns in $namespaces; do
+      log "--- inspecting namespace: $ns ---"
+      ns_has_issue=false
+
+      deploys_raw="$(oc get deploy -n "$ns" --no-headers 2>/dev/null || true)"
+      if [ -n "$deploys_raw" ]; then
+        while IFS= read -r line; do
+          [ -z "$line" ] && continue
+          read -r name ready_field _ <<< "$line"
+          ready="${ready_field%%/*}"
+          desired="${ready_field##*/}"
+          deploy_total=$((deploy_total + 1))
+          if [ "$ready" -ne "$desired" ]; then
+            log "deployment not ready: namespace=$ns name=$name ($ready/$desired)"
+            echo "$ns,$name,Deployment,$now_ts" >> "$csv_file"
+            deploy_not_ready=$((deploy_not_ready + 1))
+            ns_has_issue=true
+          fi
+        done <<< "$deploys_raw"
+      else
+        log "no deployments found for namespace $ns"
+      fi
+
+      dcs_json="$(oc get dc -n "$ns" -o json 2>/dev/null || true)"
+      if [ -n "$dcs_json" ] && [ "$(echo "$dcs_json" | jq '.items | length')" -gt 0 ]; then
+        dc_count="$(echo "$dcs_json" | jq '.items | length')"
+        for i in $(seq 0 $((dc_count - 1))); do
+          name="$(echo "$dcs_json" | jq -r ".items[$i].metadata.name")"
+          desired="$(echo "$dcs_json" | jq -r ".items[$i].spec.replicas // 0")"
+          available="$(echo "$dcs_json" | jq -r ".items[$i].status.availableReplicas // 0")"
+          dc_total=$((dc_total + 1))
+          if [ "$available" -lt "$desired" ]; then
+            log "deploymentconfig not available: namespace=$ns name=$name ($available/$desired)"
+            echo "$ns,$name,DeploymentConfig,$now_ts" >> "$csv_file"
+            dc_not_ready=$((dc_not_ready + 1))
+            ns_has_issue=true
+          fi
+        done
+      else
+        log "no deploymentconfigs found for namespace $ns"
+      fi
+
+      if [ "$ns_has_issue" = true ]; then
+        ns_with_issues=$((ns_with_issues + 1))
+        log "namespace $ns has issues"
+      else
+        log "namespace $ns is healthy"
+      fi
+    done
+
+    log "deployments checked: $deploy_total"
+    log "deployments not ready: $deploy_not_ready"
+    log "deploymentconfigs checked: $dc_total"
+    log "deploymentconfigs not available: $dc_not_ready"
+
+    total_checked=$((deploy_total + dc_total))
+    total_not_ready=$((deploy_not_ready + dc_not_ready))
+    if [ "$total_checked" -gt 0 ]; then
+      percent_not_ready=$(echo "scale=2; 100 * $total_not_ready / $total_checked" | bc -l)
+    else
+      percent_not_ready="0.00"
+    fi
+    echo "percent_not_ready,,,$percent_not_ready" >> "$csv_file"
+    log "percent of resources not ready: $percent_not_ready"
+
+    report_name="not-ready-$(date -u +%Y%m%d%H%M)"
+    upload_url="$FRONTEND_URL/reports/upload?name=$report_name"
+    log "sending csv to $upload_url"
+    if curl -s -X POST \
+        -H "Content-Type: text/plain" \
+        --data-binary @"$csv_file" \
+        "$upload_url"; then
+      log "csv uploaded: $report_name"
+    else
+      log "warning: failed to upload csv to frontend"
+    fi
+
+    log "sending summary to Microsoft Teams"
+    body="#### Resources not ready or not available\n"
+    body+="Namespaces with issues: \`$ns_with_issues\`\n"
+    body+="Deployments checked: \`$deploy_total\` / Not ready: \`$deploy_not_ready\`\n"
+    body+="DeploymentConfigs checked: \`$dc_total\` / Not available: \`$dc_not_ready\`\n"
+    body+="Percent not ready: \`$percent_not_ready%\`\n\n"
+    body+="[Open summary]($FRONTEND_URL/summary-page)\n"
+    body+="[Open details]($FRONTEND_URL/detail-page?name=$report_name)\n"
+    escaped_body="$(printf '%s' "$body" | sed ':a;N;$!ba;s/\n/\\n/g')"
+
+    json_body=$(cat <<EOF
+    {
+      "@type": "MessageCard",
+      "@context": "https://schema.org/extensions",
+      "summary": "Resources not ready in OpenShift",
+      "themeColor": "FF0000",
+      "title": "Resources not ready or not available",
+      "sections": [
+        {
+          "markdown": true,
+          "text": "${escaped_body}"
+        }
+      ]
+    }
+    EOF
+    )
+
+    if curl -s -X POST \
+        -H "Content-Type: application/json" \
+        -d "$json_body" \
+        "$TEAMS_WEBHOOK_URL"; then
+      log "summary sent to Microsoft Teams"
+    else
+      log "warning: failed to post summary to Microsoft Teams"
+    fi
+
+    log "--- finished sentik send-not-ready script ---"
+    exit 0

--- a/architecture/support-domain/sentik/cronjob.yaml
+++ b/architecture/support-domain/sentik/cronjob.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sentik-send-not-ready
+  namespace: support-domain
+  labels:
+    app: sentik
+  annotations:
+    architecture.domain: support
+    architecture.function: sentik
+    architecture.part_of: arkit8s
+spec:
+  schedule: "*/2 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: sentik-checker
+              image: registry.redhat.io/openshift4/ose-tools-rhel9
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - "/scripts/run.sh"
+              env:
+                - name: TEAMS_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: sentik-teams-webhook
+                      key: url
+                - name: FRONTEND_URL
+                  value: "http://sentik:8080"
+              volumeMounts:
+                - name: script-vol
+                  mountPath: /scripts
+          volumes:
+            - name: script-vol
+              configMap:
+                name: sentik-send-not-ready-script
+                defaultMode: 0755

--- a/architecture/support-domain/sentik/deployment.yaml
+++ b/architecture/support-domain/sentik/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sentik
+  namespace: support-domain
+  labels:
+    app: sentik
+  annotations:
+    architecture.domain: support
+    architecture.function: sentik
+    architecture.invoked_by: platform-operators
+    architecture.calls: openshift-api, microsoft-teams
+    architecture.part_of: arkit8s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sentik
+  template:
+    metadata:
+      labels:
+        app: sentik
+    spec:
+      containers:
+        - name: sentik
+          image: quay.io/sergio_canales_e/quarkus/txt-report-frontend:1.0.9
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: JAVA_OPTIONS
+              value: "-Dquarkus.http.host=0.0.0.0"
+            - name: FRONTEND_URL
+              value: "http://sentik:8080"
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+            initialDelaySeconds: 0
+            periodSeconds: 1
+            failureThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/architecture/support-domain/sentik/kustomization.yaml
+++ b/architecture/support-domain/sentik/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  arkit8s.component: sentik
+resources:
+  - configmap.yaml
+  - secret.yaml
+  - deployment.yaml
+  - service.yaml
+  - cronjob.yaml

--- a/architecture/support-domain/sentik/secret.yaml
+++ b/architecture/support-domain/sentik/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sentik-teams-webhook
+  namespace: support-domain
+  labels:
+    app: sentik
+  annotations:
+    architecture.domain: support
+    architecture.function: sentik
+    architecture.part_of: arkit8s
+type: Opaque
+stringData:
+  url: "https://example.com/your-teams-webhook"

--- a/architecture/support-domain/sentik/service.yaml
+++ b/architecture/support-domain/sentik/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sentik
+  namespace: support-domain
+  labels:
+    app: sentik
+  annotations:
+    architecture.domain: support
+    architecture.function: sentik
+    architecture.part_of: arkit8s
+spec:
+  selector:
+    app: sentik
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- add a new sentik component under the support domain to deploy the Quarkus txt-report frontend
- provide deployment, service, configmap, secret, and cronjob manifests that mirror the upstream project defaults
- include the sentik component in the support-domain kustomization so it is installed with the rest of the domain

## Testing
- ⚠️ `kustomize build architecture/support-domain/sentik` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e5bee2d6808333aba54ee9235c3a69