### PR TITLE
Documenta uso de arkit8s y sincroniza ayuda del CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # RHBK on CRC
 
-Despliega Red Hat Build of Keycloak en OpenShift Local (CRC) usando Kustomize.
+Este repositorio despliega Red Hat Build of Keycloak sobre OpenShift Local (CRC) usando Kustomize y aporta un conjunto de utilidades operativas agrupadas en el CLI `arkit8s.py`.
 
-## Requisitos
-- CRC en ejecución y accesible
-- `oc login` contra el clúster
+## Requisitos generales
+
+- CRC u otro clúster OpenShift en ejecución y accesible.
+- Autenticarse con `oc login` contra el clúster objetivo.
+- Contar con `diffutils`, `jq` y `curl` en el `PATH` para las tareas auxiliares de validación y monitoreo.
+- Python 3.9+ para ejecutar `arkit8s.py`.
 
 ## Instalación rápida (DEV/CRC)
 
@@ -12,17 +15,69 @@ Despliega Red Hat Build of Keycloak en OpenShift Local (CRC) usando Kustomize.
 make crc-dev
 ```
 
-## Comandos útiles
-- `make wait` – espera a que Keycloak esté listo
-- `make admin` – muestra las credenciales iniciales
-- `make open` – imprime la URL de acceso
+## Comandos útiles de Makefile
 
-## Desinstalación
+- `make wait` – espera a que Keycloak esté listo.
+- `make admin` – muestra las credenciales iniciales.
+- `make open` – imprime la URL de acceso.
+
+## Desinstalación completa
 
 ```bash
 make destroy
 ```
 
-## Notas de producción
+## Notas para entornos productivos
 
 Para producción usa el overlay `shared-components/keycloak/overlays/prod`, una base de datos externa y configura TLS y Routes reencrypt/passthrough.
+
+## Uso del CLI `arkit8s`
+
+<!-- BEGIN ARKIT8S HELP -->
+El script `arkit8s.py` centraliza las tareas operativas de la plataforma. Todos los comandos deben ejecutarse desde la raíz del repositorio.
+
+### Prerrequisitos del CLI
+
+1. Ejecuta `oc login` contra el clúster de destino con un usuario con permisos para crear namespaces y aplicar manifiestos.
+2. Verifica que `diff`, `jq` y `curl` estén disponibles; se utilizan para validaciones y recopilación de métricas.
+3. Si trabajas con varios entornos, revisa el directorio `environments/` y selecciona el overlay adecuado (por defecto `sandbox`).
+
+### Flujo sugerido
+
+1. **Instala** los manifiestos del entorno: `./arkit8s.py install --env sandbox`.
+2. **Valida** que el clúster quedó en sincronía: `./arkit8s.py validate-cluster --env sandbox`.
+3. **Monitorea** durante unos minutos para detectar desincronizaciones: `./arkit8s.py watch --env sandbox --minutes 5`.
+4. **Genera reportes** o valida metadatos según sea necesario.
+
+### Subcomandos disponibles
+
+> Todos los subcomandos aceptan `--help` para mostrar su resumen puntual.
+
+- `install [--env <nombre>]` – aplica los manifiestos base (`architecture/bootstrap`) y los del entorno indicado en `environments/`. Útil para una instalación inicial o para reconciliar cambios.
+- `uninstall` – elimina los recursos definidos en `architecture/` (incluyendo bootstrap). No falla si los recursos ya no existen.
+- `validate-cluster [--env <nombre>]` – revisa namespaces, deployments, pods y sincronización (`oc diff`) para asegurar que el estado del clúster coincide con los manifiestos.
+- `watch [--env <nombre>] [--minutes <n>] [--detail <default|detailed|all>]` – ejecuta validaciones continuas cada 30 segundos durante el tiempo indicado. Con `--detail` distinto de `default` imprime el inventario de recursos monitoreados.
+- `validate-yaml` – recorre el repositorio y verifica que todos los YAML (excepto `kustomization.yaml`) sean sintácticamente válidos.
+- `report` – genera un reporte Markdown con trazabilidad de componentes y relaciones usando las anotaciones `architecture.*`.
+- `validate-metadata` – comprueba coherencia entre los campos `calls`/`invoked_by` y que las NetworkPolicies permitan el tráfico declarado.
+- `generate-network-policies` – produce manifiestos de NetworkPolicy derivados de las anotaciones de dependencias (útil para revisiones o generación automatizada).
+- `create-component --type <tipo> --domain <business|support|shared> --branch <rama>` – crea una instancia de componente a partir del inventario (`component_inventory.yaml`), generando Deployment/Service/Kustomization y actualizando el `kustomization.yaml` del dominio.
+
+### Ejemplo práctico: instalar **Sentik**
+
+1. **Configura credenciales**: edita `architecture/support-domain/sentik/secret.yaml` para colocar la URL real del webhook de Microsoft Teams (`stringData.url`).
+2. **Ajusta la URL del frontend** si corresponde: en `architecture/support-domain/sentik/cronjob.yaml` o mediante variables de entorno modifica el valor de `FRONTEND_URL` para apuntar al servicio que consumirá los reportes (por defecto `http://sentik:8080`).
+3. **Aplica el entorno** deseado: `./arkit8s.py install --env sandbox`. Esto creará el namespace `support-domain`, desplegará el Deployment, Service, CronJob y ConfigMap asociados a Sentik.
+4. **Verifica el estado**: 
+   - `./arkit8s.py validate-cluster --env sandbox` para asegurar sincronización.
+   - `oc get pods -n support-domain` para confirmar que el Deployment `sentik` está `Running`.
+   - `oc get cronjob -n support-domain sentik-send-not-ready` para revisar el agendamiento.
+5. **Monitorea ejecuciones**: usa `./arkit8s.py watch --env sandbox --minutes 10 --detail detailed` para observar reinicios o fallas en los pods disparados por el CronJob.
+
+### Buenas prácticas y solución de problemas
+
+- Ejecuta `./arkit8s.py validate-yaml` antes de aplicar cambios para detectar errores de formato.
+- Usa `./arkit8s.py validate-metadata` después de editar anotaciones de arquitectura para mantener la trazabilidad consistente.
+- Si necesitas revisar o compartir el estado de la arquitectura, ejecuta `./arkit8s.py report > reporte.md` y distribuye el archivo generado.
+- Ante diferencias entre manifiestos y clúster, vuelve a ejecutar `install` o revisa `oc diff -k environments/<env>` para entender los cambios pendientes.
+<!-- END ARKIT8S HELP -->

--- a/arkit8s.py
+++ b/arkit8s.py
@@ -9,10 +9,33 @@ import sys
 import time
 from pathlib import Path
 
+HELP_START_MARKER = "<!-- BEGIN ARKIT8S HELP -->"
+HELP_END_MARKER = "<!-- END ARKIT8S HELP -->"
+
 REPO_ROOT = Path(__file__).resolve().parent
 ARCH_DIR = REPO_ROOT / "architecture"
 UTIL_DIR = REPO_ROOT / "utilities"
 ENV_DIR = REPO_ROOT / "environments"
+
+
+def _load_usage_text() -> str:
+    """Return the README help block so CLI help matches documentation."""
+    readme = REPO_ROOT / "README.md"
+    try:
+        content = readme.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return "arkit8s utility CLI"
+
+    start = content.find(HELP_START_MARKER)
+    end = content.find(HELP_END_MARKER)
+    if start == -1 or end == -1 or end <= start:
+        return "arkit8s utility CLI"
+
+    help_block = content[start + len(HELP_START_MARKER):end]
+    return help_block.strip() or "arkit8s utility CLI"
+
+
+USAGE_TEXT = _load_usage_text()
 
 
 def run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
@@ -595,7 +618,10 @@ spec:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="arkit8s utility CLI")
+    parser = argparse.ArgumentParser(
+        description=USAGE_TEXT,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     sub = parser.add_subparsers(dest="command")
 
     p_install = sub.add_parser("install", help="Install manifests via oc apply")


### PR DESCRIPTION
## Summary
- amplía el README con las instrucciones completas del CLI arkit8s, incluyendo un flujo sugerido y la guía para desplegar Sentik
- extrae el bloque de ayuda del README para que `arkit8s.py --help` muestre la misma información documental

## Testing
- python3 arkit8s.py --help

------
https://chatgpt.com/codex/tasks/task_e_68e5c27c763c8333b74899ebed5f0e7c