### PR TITLE
Add dynamic scheduling for simulator behaviors

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,17 @@ El script `arkit8s.py` centraliza las tareas operativas de la plataforma. Todos 
 - `report` – genera un reporte Markdown con trazabilidad de componentes y relaciones usando las anotaciones `architecture.*`.
 - `validate-metadata` – comprueba coherencia entre los campos `calls`/`invoked_by` y que las NetworkPolicies permitan el tráfico declarado.
 - `generate-network-policies` – produce manifiestos de NetworkPolicy derivados de las anotaciones de dependencias (útil para revisiones o generación automatizada).
-- `generate-load-simulators [--count <n>] [--targets <componentes>] [--seed <n>]` – crea Deployments sintéticos con comportamientos aleatorios (`ok`, `notready`, `restart`) tomando como referencia el repositorio [`quarkus-txt-report-frontend`](https://github.com/scanalesespinoza/quarkus-txt-report-frontend). Útil para ejercitar dominios de negocio y validar el flujo de reportes.
+- `generate-load-simulators [--count <n>] [--targets <componentes>] [--seed <n>] [--behavior <dynamic|ok|notready|restart>]` – crea Deployments sintéticos que, por omisión, alternan aleatoriamente entre `ok`, `notready` y `restart` cada 1–60 minutos para simular incidentes realistas. Con `--behavior` puedes fijar un estado específico.
 - `list-load-simulators` – consulta en el clúster todos los Deployments etiquetados como simuladores (`arkit8s.simulator=true`) e imprime el namespace, nombre y comportamiento (`BEHAVIOR`) asignado a cada uno.
 - `cleanup-load-simulators [--branch <nombre>] [--targets <componentes>]` – elimina los simuladores del clúster, borra los manifiestos `load-simulators.yaml` generados por el comando y retira su referencia de los `kustomization.yaml`.  Después de ejecutar la limpieza, cambia a tu rama principal (`git switch main`) y elimina la rama temporal (`git branch -D <nombre>`).
 - `create-component --type <tipo> --domain <business|support|shared> --branch <rama>` – crea una instancia de componente a partir del inventario (`component_inventory.yaml`), generando Deployment/Service/Kustomization y actualizando el `kustomization.yaml` del dominio.
+
+#### Ejemplos de uso de simuladores de carga
+
+- `./arkit8s.py generate-load-simulators` – genera simuladores con comportamiento dinámico: cada pod cambia aleatoriamente entre `ok`, `notready` y `restart` en intervalos aleatorios de 1 a 60 minutos.
+- `./arkit8s.py generate-load-simulators --behavior notready` – todos los simuladores permanecen permanentemente en estado `notready`, útil para probar alertas de disponibilidad.
+- `./arkit8s.py generate-load-simulators --behavior ok` – los simuladores se mantienen estables y siempre listos, ideal para validar flujos felices sin interrupciones.
+- `./arkit8s.py generate-load-simulators --behavior restart` – los simuladores reinician periódicamente tras 60 segundos, ideal para evaluar tolerancia a reinicios.
 
 ### Ejemplo práctico: instalar **Sentik**
 

--- a/architecture/business-domain/api/load-simulators.yaml
+++ b/architecture/business-domain/api/load-simulators.yaml
@@ -30,26 +30,129 @@ spec:
           image: registry.access.redhat.com/ubi10/ubi-minimal
           env:
             - name: BEHAVIOR
-              value: "restart"
+              value: "dynamic"
+            - name: BEHAVIOR_SEED
+              value: "1502714691"
           command:
             - sh
             - -c
             - |
-              echo "[$(date -u)] starting with BEHAVIOR=$BEHAVIOR"
-              if [ "$BEHAVIOR" = "restart" ]; then
-                sleep 60
-                echo "[$(date -u)] simulating crash to trigger restart"
-                exit 1
-              elif [ "$BEHAVIOR" = "notready" ]; then
-                while true; do
-                  sleep 30
+              STATE_FILE="/tmp/current_behavior"
+              BEHAVIOR=${BEHAVIOR:-dynamic}
+              BEHAVIOR_SEED=${BEHAVIOR_SEED:-}
+              BEHAVIOR_CHOICES="ok notready restart"
+              RANDOM_COUNTER=0
+
+              log() {
+                echo "[$(date -u)] $*"
+              }
+
+              write_state() {
+                printf '%s\n' "$1" > "$STATE_FILE"
+              }
+
+              next_random() {
+                if [ -n "$BEHAVIOR_SEED" ]; then
+                  value=$(awk -v seed="$BEHAVIOR_SEED" -v step="$RANDOM_COUNTER" 'BEGIN { srand(seed + step); printf "%d\n", int(rand() * 32768) }')
+                else
+                  value=$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')
+                fi
+                RANDOM_COUNTER=$((RANDOM_COUNTER + 1))
+                printf '%s\n' "${value:-0}"
+              }
+
+              choose_behavior() {
+                set -- $BEHAVIOR_CHOICES
+                count=$#
+                if [ "$count" -eq 0 ]; then
+                  printf 'ok\n'
+                  return
+                fi
+                rand=$(next_random)
+                idx=$((rand % count + 1))
+                i=1
+                for option in "$@"; do
+                  if [ "$i" -eq "$idx" ]; then
+                    printf '%s\n' "$option"
+                    return
+                  fi
+                  i=$((i + 1))
                 done
-              else
-                while true; do
-                  echo "[$(date -u)] running normally (BEHAVIOR=$BEHAVIOR)"
-                  sleep 30
+                printf '%s\n' "$1"
+              }
+
+              random_minutes() {
+                rand=$(next_random)
+                printf '%s\n' $((rand % 60 + 1))
+              }
+
+              wait_duration() {
+                duration_seconds=$1
+                behavior_label=$2
+                end=$(( $(date +%s) + duration_seconds ))
+                while [ "$(date +%s)" -lt "$end" ]; do
+                  case "$behavior_label" in
+                    ok)
+                      log "running normally (dynamic ok)"
+                      sleep 30
+                      ;;
+                    notready)
+                      sleep 30
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
                 done
+              }
+
+              log "starting with BEHAVIOR=$BEHAVIOR"
+              write_state "$BEHAVIOR"
+
+              if [ "$BEHAVIOR" != "dynamic" ]; then
+                case "$BEHAVIOR" in
+                  restart)
+                    sleep 60
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    while true; do
+                      sleep 30
+                    done
+                    ;;
+                  *)
+                    while true; do
+                      log "running normally (BEHAVIOR=$BEHAVIOR)"
+                      sleep 30
+                    done
+                    ;;
+                esac
               fi
+
+              log "enabling dynamic behavior changes"
+              while true; do
+                next=$(choose_behavior)
+                minutes=$(random_minutes)
+                seconds=$((minutes * 60))
+                write_state "$next"
+                case "$next" in
+                  restart)
+                    log "switching to restart behavior for ${minutes} minute(s)"
+                    sleep "$seconds"
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    log "switching to notready behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                  *)
+                    log "switching to ok behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                esac
+              done
           livenessProbe:
             exec:
               command:
@@ -64,7 +167,12 @@ spec:
                 - sh
                 - -c
                 - |
-                  if [ "$BEHAVIOR" = "notready" ]; then
+                  STATE_FILE="/tmp/current_behavior"
+                  current="$BEHAVIOR"
+                  if [ -f "$STATE_FILE" ]; then
+                    current=$(cat "$STATE_FILE" 2>/dev/null || echo "$current")
+                  fi
+                  if [ "$current" = "notready" ]; then
                     exit 1
                   else
                     exit 0
@@ -102,26 +210,129 @@ spec:
           image: registry.access.redhat.com/ubi10/ubi-minimal
           env:
             - name: BEHAVIOR
-              value: "ok"
+              value: "dynamic"
+            - name: BEHAVIOR_SEED
+              value: "809592186"
           command:
             - sh
             - -c
             - |
-              echo "[$(date -u)] starting with BEHAVIOR=$BEHAVIOR"
-              if [ "$BEHAVIOR" = "restart" ]; then
-                sleep 60
-                echo "[$(date -u)] simulating crash to trigger restart"
-                exit 1
-              elif [ "$BEHAVIOR" = "notready" ]; then
-                while true; do
-                  sleep 30
+              STATE_FILE="/tmp/current_behavior"
+              BEHAVIOR=${BEHAVIOR:-dynamic}
+              BEHAVIOR_SEED=${BEHAVIOR_SEED:-}
+              BEHAVIOR_CHOICES="ok notready restart"
+              RANDOM_COUNTER=0
+
+              log() {
+                echo "[$(date -u)] $*"
+              }
+
+              write_state() {
+                printf '%s\n' "$1" > "$STATE_FILE"
+              }
+
+              next_random() {
+                if [ -n "$BEHAVIOR_SEED" ]; then
+                  value=$(awk -v seed="$BEHAVIOR_SEED" -v step="$RANDOM_COUNTER" 'BEGIN { srand(seed + step); printf "%d\n", int(rand() * 32768) }')
+                else
+                  value=$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')
+                fi
+                RANDOM_COUNTER=$((RANDOM_COUNTER + 1))
+                printf '%s\n' "${value:-0}"
+              }
+
+              choose_behavior() {
+                set -- $BEHAVIOR_CHOICES
+                count=$#
+                if [ "$count" -eq 0 ]; then
+                  printf 'ok\n'
+                  return
+                fi
+                rand=$(next_random)
+                idx=$((rand % count + 1))
+                i=1
+                for option in "$@"; do
+                  if [ "$i" -eq "$idx" ]; then
+                    printf '%s\n' "$option"
+                    return
+                  fi
+                  i=$((i + 1))
                 done
-              else
-                while true; do
-                  echo "[$(date -u)] running normally (BEHAVIOR=$BEHAVIOR)"
-                  sleep 30
+                printf '%s\n' "$1"
+              }
+
+              random_minutes() {
+                rand=$(next_random)
+                printf '%s\n' $((rand % 60 + 1))
+              }
+
+              wait_duration() {
+                duration_seconds=$1
+                behavior_label=$2
+                end=$(( $(date +%s) + duration_seconds ))
+                while [ "$(date +%s)" -lt "$end" ]; do
+                  case "$behavior_label" in
+                    ok)
+                      log "running normally (dynamic ok)"
+                      sleep 30
+                      ;;
+                    notready)
+                      sleep 30
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
                 done
+              }
+
+              log "starting with BEHAVIOR=$BEHAVIOR"
+              write_state "$BEHAVIOR"
+
+              if [ "$BEHAVIOR" != "dynamic" ]; then
+                case "$BEHAVIOR" in
+                  restart)
+                    sleep 60
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    while true; do
+                      sleep 30
+                    done
+                    ;;
+                  *)
+                    while true; do
+                      log "running normally (BEHAVIOR=$BEHAVIOR)"
+                      sleep 30
+                    done
+                    ;;
+                esac
               fi
+
+              log "enabling dynamic behavior changes"
+              while true; do
+                next=$(choose_behavior)
+                minutes=$(random_minutes)
+                seconds=$((minutes * 60))
+                write_state "$next"
+                case "$next" in
+                  restart)
+                    log "switching to restart behavior for ${minutes} minute(s)"
+                    sleep "$seconds"
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    log "switching to notready behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                  *)
+                    log "switching to ok behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                esac
+              done
           livenessProbe:
             exec:
               command:
@@ -136,7 +347,192 @@ spec:
                 - sh
                 - -c
                 - |
-                  if [ "$BEHAVIOR" = "notready" ]; then
+                  STATE_FILE="/tmp/current_behavior"
+                  current="$BEHAVIOR"
+                  if [ -f "$STATE_FILE" ]; then
+                    current=$(cat "$STATE_FILE" 2>/dev/null || echo "$current")
+                  fi
+                  if [ "$current" = "notready" ]; then
+                    exit 1
+                  else
+                    exit 0
+                  fi
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-availability-sim-3
+  namespace: business-domain
+  labels:
+    app: api-availability-sim-3
+    arkit8s.simulator: "true"
+  annotations:
+    architecture.domain: business
+    architecture.function: api-load-simulator
+    architecture.simulates: api-app-instance
+    architecture.part_of: arkit8s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-availability-sim-3
+  template:
+    metadata:
+      labels:
+        app: api-availability-sim-3
+        arkit8s.simulator: "true"
+        arkit8s.simulates: api-app-instance
+    spec:
+      containers:
+        - name: availability-simulator
+          image: registry.access.redhat.com/ubi10/ubi-minimal
+          env:
+            - name: BEHAVIOR
+              value: "dynamic"
+            - name: BEHAVIOR_SEED
+              value: "1487238930"
+          command:
+            - sh
+            - -c
+            - |
+              STATE_FILE="/tmp/current_behavior"
+              BEHAVIOR=${BEHAVIOR:-dynamic}
+              BEHAVIOR_SEED=${BEHAVIOR_SEED:-}
+              BEHAVIOR_CHOICES="ok notready restart"
+              RANDOM_COUNTER=0
+
+              log() {
+                echo "[$(date -u)] $*"
+              }
+
+              write_state() {
+                printf '%s\n' "$1" > "$STATE_FILE"
+              }
+
+              next_random() {
+                if [ -n "$BEHAVIOR_SEED" ]; then
+                  value=$(awk -v seed="$BEHAVIOR_SEED" -v step="$RANDOM_COUNTER" 'BEGIN { srand(seed + step); printf "%d\n", int(rand() * 32768) }')
+                else
+                  value=$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')
+                fi
+                RANDOM_COUNTER=$((RANDOM_COUNTER + 1))
+                printf '%s\n' "${value:-0}"
+              }
+
+              choose_behavior() {
+                set -- $BEHAVIOR_CHOICES
+                count=$#
+                if [ "$count" -eq 0 ]; then
+                  printf 'ok\n'
+                  return
+                fi
+                rand=$(next_random)
+                idx=$((rand % count + 1))
+                i=1
+                for option in "$@"; do
+                  if [ "$i" -eq "$idx" ]; then
+                    printf '%s\n' "$option"
+                    return
+                  fi
+                  i=$((i + 1))
+                done
+                printf '%s\n' "$1"
+              }
+
+              random_minutes() {
+                rand=$(next_random)
+                printf '%s\n' $((rand % 60 + 1))
+              }
+
+              wait_duration() {
+                duration_seconds=$1
+                behavior_label=$2
+                end=$(( $(date +%s) + duration_seconds ))
+                while [ "$(date +%s)" -lt "$end" ]; do
+                  case "$behavior_label" in
+                    ok)
+                      log "running normally (dynamic ok)"
+                      sleep 30
+                      ;;
+                    notready)
+                      sleep 30
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
+                done
+              }
+
+              log "starting with BEHAVIOR=$BEHAVIOR"
+              write_state "$BEHAVIOR"
+
+              if [ "$BEHAVIOR" != "dynamic" ]; then
+                case "$BEHAVIOR" in
+                  restart)
+                    sleep 60
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    while true; do
+                      sleep 30
+                    done
+                    ;;
+                  *)
+                    while true; do
+                      log "running normally (BEHAVIOR=$BEHAVIOR)"
+                      sleep 30
+                    done
+                    ;;
+                esac
+              fi
+
+              log "enabling dynamic behavior changes"
+              while true; do
+                next=$(choose_behavior)
+                minutes=$(random_minutes)
+                seconds=$((minutes * 60))
+                write_state "$next"
+                case "$next" in
+                  restart)
+                    log "switching to restart behavior for ${minutes} minute(s)"
+                    sleep "$seconds"
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    log "switching to notready behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                  *)
+                    log "switching to ok behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                esac
+              done
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exit 0
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  STATE_FILE="/tmp/current_behavior"
+                  current="$BEHAVIOR"
+                  if [ -f "$STATE_FILE" ]; then
+                    current=$(cat "$STATE_FILE" 2>/dev/null || echo "$current")
+                  fi
+                  if [ "$current" = "notready" ]; then
                     exit 1
                   else
                     exit 0

--- a/architecture/business-domain/company-management/identity-verification/load-simulators.yaml
+++ b/architecture/business-domain/company-management/identity-verification/load-simulators.yaml
@@ -30,26 +30,129 @@ spec:
           image: registry.access.redhat.com/ubi10/ubi-minimal
           env:
             - name: BEHAVIOR
-              value: "ok"
+              value: "dynamic"
+            - name: BEHAVIOR_SEED
+              value: "2120727925"
           command:
             - sh
             - -c
             - |
-              echo "[$(date -u)] starting with BEHAVIOR=$BEHAVIOR"
-              if [ "$BEHAVIOR" = "restart" ]; then
-                sleep 60
-                echo "[$(date -u)] simulating crash to trigger restart"
-                exit 1
-              elif [ "$BEHAVIOR" = "notready" ]; then
-                while true; do
-                  sleep 30
+              STATE_FILE="/tmp/current_behavior"
+              BEHAVIOR=${BEHAVIOR:-dynamic}
+              BEHAVIOR_SEED=${BEHAVIOR_SEED:-}
+              BEHAVIOR_CHOICES="ok notready restart"
+              RANDOM_COUNTER=0
+
+              log() {
+                echo "[$(date -u)] $*"
+              }
+
+              write_state() {
+                printf '%s\n' "$1" > "$STATE_FILE"
+              }
+
+              next_random() {
+                if [ -n "$BEHAVIOR_SEED" ]; then
+                  value=$(awk -v seed="$BEHAVIOR_SEED" -v step="$RANDOM_COUNTER" 'BEGIN { srand(seed + step); printf "%d\n", int(rand() * 32768) }')
+                else
+                  value=$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')
+                fi
+                RANDOM_COUNTER=$((RANDOM_COUNTER + 1))
+                printf '%s\n' "${value:-0}"
+              }
+
+              choose_behavior() {
+                set -- $BEHAVIOR_CHOICES
+                count=$#
+                if [ "$count" -eq 0 ]; then
+                  printf 'ok\n'
+                  return
+                fi
+                rand=$(next_random)
+                idx=$((rand % count + 1))
+                i=1
+                for option in "$@"; do
+                  if [ "$i" -eq "$idx" ]; then
+                    printf '%s\n' "$option"
+                    return
+                  fi
+                  i=$((i + 1))
                 done
-              else
-                while true; do
-                  echo "[$(date -u)] running normally (BEHAVIOR=$BEHAVIOR)"
-                  sleep 30
+                printf '%s\n' "$1"
+              }
+
+              random_minutes() {
+                rand=$(next_random)
+                printf '%s\n' $((rand % 60 + 1))
+              }
+
+              wait_duration() {
+                duration_seconds=$1
+                behavior_label=$2
+                end=$(( $(date +%s) + duration_seconds ))
+                while [ "$(date +%s)" -lt "$end" ]; do
+                  case "$behavior_label" in
+                    ok)
+                      log "running normally (dynamic ok)"
+                      sleep 30
+                      ;;
+                    notready)
+                      sleep 30
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
                 done
+              }
+
+              log "starting with BEHAVIOR=$BEHAVIOR"
+              write_state "$BEHAVIOR"
+
+              if [ "$BEHAVIOR" != "dynamic" ]; then
+                case "$BEHAVIOR" in
+                  restart)
+                    sleep 60
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    while true; do
+                      sleep 30
+                    done
+                    ;;
+                  *)
+                    while true; do
+                      log "running normally (BEHAVIOR=$BEHAVIOR)"
+                      sleep 30
+                    done
+                    ;;
+                esac
               fi
+
+              log "enabling dynamic behavior changes"
+              while true; do
+                next=$(choose_behavior)
+                minutes=$(random_minutes)
+                seconds=$((minutes * 60))
+                write_state "$next"
+                case "$next" in
+                  restart)
+                    log "switching to restart behavior for ${minutes} minute(s)"
+                    sleep "$seconds"
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    log "switching to notready behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                  *)
+                    log "switching to ok behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                esac
+              done
           livenessProbe:
             exec:
               command:
@@ -64,7 +167,12 @@ spec:
                 - sh
                 - -c
                 - |
-                  if [ "$BEHAVIOR" = "notready" ]; then
+                  STATE_FILE="/tmp/current_behavior"
+                  current="$BEHAVIOR"
+                  if [ -f "$STATE_FILE" ]; then
+                    current=$(cat "$STATE_FILE" 2>/dev/null || echo "$current")
+                  fi
+                  if [ "$current" = "notready" ]; then
                     exit 1
                   else
                     exit 0
@@ -102,26 +210,129 @@ spec:
           image: registry.access.redhat.com/ubi10/ubi-minimal
           env:
             - name: BEHAVIOR
-              value: "restart"
+              value: "dynamic"
+            - name: BEHAVIOR_SEED
+              value: "1522001126"
           command:
             - sh
             - -c
             - |
-              echo "[$(date -u)] starting with BEHAVIOR=$BEHAVIOR"
-              if [ "$BEHAVIOR" = "restart" ]; then
-                sleep 60
-                echo "[$(date -u)] simulating crash to trigger restart"
-                exit 1
-              elif [ "$BEHAVIOR" = "notready" ]; then
-                while true; do
-                  sleep 30
+              STATE_FILE="/tmp/current_behavior"
+              BEHAVIOR=${BEHAVIOR:-dynamic}
+              BEHAVIOR_SEED=${BEHAVIOR_SEED:-}
+              BEHAVIOR_CHOICES="ok notready restart"
+              RANDOM_COUNTER=0
+
+              log() {
+                echo "[$(date -u)] $*"
+              }
+
+              write_state() {
+                printf '%s\n' "$1" > "$STATE_FILE"
+              }
+
+              next_random() {
+                if [ -n "$BEHAVIOR_SEED" ]; then
+                  value=$(awk -v seed="$BEHAVIOR_SEED" -v step="$RANDOM_COUNTER" 'BEGIN { srand(seed + step); printf "%d\n", int(rand() * 32768) }')
+                else
+                  value=$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')
+                fi
+                RANDOM_COUNTER=$((RANDOM_COUNTER + 1))
+                printf '%s\n' "${value:-0}"
+              }
+
+              choose_behavior() {
+                set -- $BEHAVIOR_CHOICES
+                count=$#
+                if [ "$count" -eq 0 ]; then
+                  printf 'ok\n'
+                  return
+                fi
+                rand=$(next_random)
+                idx=$((rand % count + 1))
+                i=1
+                for option in "$@"; do
+                  if [ "$i" -eq "$idx" ]; then
+                    printf '%s\n' "$option"
+                    return
+                  fi
+                  i=$((i + 1))
                 done
-              else
-                while true; do
-                  echo "[$(date -u)] running normally (BEHAVIOR=$BEHAVIOR)"
-                  sleep 30
+                printf '%s\n' "$1"
+              }
+
+              random_minutes() {
+                rand=$(next_random)
+                printf '%s\n' $((rand % 60 + 1))
+              }
+
+              wait_duration() {
+                duration_seconds=$1
+                behavior_label=$2
+                end=$(( $(date +%s) + duration_seconds ))
+                while [ "$(date +%s)" -lt "$end" ]; do
+                  case "$behavior_label" in
+                    ok)
+                      log "running normally (dynamic ok)"
+                      sleep 30
+                      ;;
+                    notready)
+                      sleep 30
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
                 done
+              }
+
+              log "starting with BEHAVIOR=$BEHAVIOR"
+              write_state "$BEHAVIOR"
+
+              if [ "$BEHAVIOR" != "dynamic" ]; then
+                case "$BEHAVIOR" in
+                  restart)
+                    sleep 60
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    while true; do
+                      sleep 30
+                    done
+                    ;;
+                  *)
+                    while true; do
+                      log "running normally (BEHAVIOR=$BEHAVIOR)"
+                      sleep 30
+                    done
+                    ;;
+                esac
               fi
+
+              log "enabling dynamic behavior changes"
+              while true; do
+                next=$(choose_behavior)
+                minutes=$(random_minutes)
+                seconds=$((minutes * 60))
+                write_state "$next"
+                case "$next" in
+                  restart)
+                    log "switching to restart behavior for ${minutes} minute(s)"
+                    sleep "$seconds"
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    log "switching to notready behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                  *)
+                    log "switching to ok behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                esac
+              done
           livenessProbe:
             exec:
               command:
@@ -136,7 +347,192 @@ spec:
                 - sh
                 - -c
                 - |
-                  if [ "$BEHAVIOR" = "notready" ]; then
+                  STATE_FILE="/tmp/current_behavior"
+                  current="$BEHAVIOR"
+                  if [ -f "$STATE_FILE" ]; then
+                    current=$(cat "$STATE_FILE" 2>/dev/null || echo "$current")
+                  fi
+                  if [ "$current" = "notready" ]; then
+                    exit 1
+                  else
+                    exit 0
+                  fi
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: company-identity-availability-sim-3
+  namespace: business-domain
+  labels:
+    app: company-identity-availability-sim-3
+    arkit8s.simulator: "true"
+  annotations:
+    architecture.domain: business
+    architecture.function: company-identity-load-simulator
+    architecture.simulates: company-identity-verification-app-instance
+    architecture.part_of: arkit8s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: company-identity-availability-sim-3
+  template:
+    metadata:
+      labels:
+        app: company-identity-availability-sim-3
+        arkit8s.simulator: "true"
+        arkit8s.simulates: company-identity-verification-app-instance
+    spec:
+      containers:
+        - name: availability-simulator
+          image: registry.access.redhat.com/ubi10/ubi-minimal
+          env:
+            - name: BEHAVIOR
+              value: "dynamic"
+            - name: BEHAVIOR_SEED
+              value: "324067846"
+          command:
+            - sh
+            - -c
+            - |
+              STATE_FILE="/tmp/current_behavior"
+              BEHAVIOR=${BEHAVIOR:-dynamic}
+              BEHAVIOR_SEED=${BEHAVIOR_SEED:-}
+              BEHAVIOR_CHOICES="ok notready restart"
+              RANDOM_COUNTER=0
+
+              log() {
+                echo "[$(date -u)] $*"
+              }
+
+              write_state() {
+                printf '%s\n' "$1" > "$STATE_FILE"
+              }
+
+              next_random() {
+                if [ -n "$BEHAVIOR_SEED" ]; then
+                  value=$(awk -v seed="$BEHAVIOR_SEED" -v step="$RANDOM_COUNTER" 'BEGIN { srand(seed + step); printf "%d\n", int(rand() * 32768) }')
+                else
+                  value=$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')
+                fi
+                RANDOM_COUNTER=$((RANDOM_COUNTER + 1))
+                printf '%s\n' "${value:-0}"
+              }
+
+              choose_behavior() {
+                set -- $BEHAVIOR_CHOICES
+                count=$#
+                if [ "$count" -eq 0 ]; then
+                  printf 'ok\n'
+                  return
+                fi
+                rand=$(next_random)
+                idx=$((rand % count + 1))
+                i=1
+                for option in "$@"; do
+                  if [ "$i" -eq "$idx" ]; then
+                    printf '%s\n' "$option"
+                    return
+                  fi
+                  i=$((i + 1))
+                done
+                printf '%s\n' "$1"
+              }
+
+              random_minutes() {
+                rand=$(next_random)
+                printf '%s\n' $((rand % 60 + 1))
+              }
+
+              wait_duration() {
+                duration_seconds=$1
+                behavior_label=$2
+                end=$(( $(date +%s) + duration_seconds ))
+                while [ "$(date +%s)" -lt "$end" ]; do
+                  case "$behavior_label" in
+                    ok)
+                      log "running normally (dynamic ok)"
+                      sleep 30
+                      ;;
+                    notready)
+                      sleep 30
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
+                done
+              }
+
+              log "starting with BEHAVIOR=$BEHAVIOR"
+              write_state "$BEHAVIOR"
+
+              if [ "$BEHAVIOR" != "dynamic" ]; then
+                case "$BEHAVIOR" in
+                  restart)
+                    sleep 60
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    while true; do
+                      sleep 30
+                    done
+                    ;;
+                  *)
+                    while true; do
+                      log "running normally (BEHAVIOR=$BEHAVIOR)"
+                      sleep 30
+                    done
+                    ;;
+                esac
+              fi
+
+              log "enabling dynamic behavior changes"
+              while true; do
+                next=$(choose_behavior)
+                minutes=$(random_minutes)
+                seconds=$((minutes * 60))
+                write_state "$next"
+                case "$next" in
+                  restart)
+                    log "switching to restart behavior for ${minutes} minute(s)"
+                    sleep "$seconds"
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    log "switching to notready behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                  *)
+                    log "switching to ok behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                esac
+              done
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exit 0
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  STATE_FILE="/tmp/current_behavior"
+                  current="$BEHAVIOR"
+                  if [ -f "$STATE_FILE" ]; then
+                    current=$(cat "$STATE_FILE" 2>/dev/null || echo "$current")
+                  fi
+                  if [ "$current" = "notready" ]; then
                     exit 1
                   else
                     exit 0

--- a/architecture/business-domain/person-management/identity-verification/load-simulators.yaml
+++ b/architecture/business-domain/person-management/identity-verification/load-simulators.yaml
@@ -30,26 +30,129 @@ spec:
           image: registry.access.redhat.com/ubi10/ubi-minimal
           env:
             - name: BEHAVIOR
-              value: "notready"
+              value: "dynamic"
+            - name: BEHAVIOR_SEED
+              value: "1894882143"
           command:
             - sh
             - -c
             - |
-              echo "[$(date -u)] starting with BEHAVIOR=$BEHAVIOR"
-              if [ "$BEHAVIOR" = "restart" ]; then
-                sleep 60
-                echo "[$(date -u)] simulating crash to trigger restart"
-                exit 1
-              elif [ "$BEHAVIOR" = "notready" ]; then
-                while true; do
-                  sleep 30
+              STATE_FILE="/tmp/current_behavior"
+              BEHAVIOR=${BEHAVIOR:-dynamic}
+              BEHAVIOR_SEED=${BEHAVIOR_SEED:-}
+              BEHAVIOR_CHOICES="ok notready restart"
+              RANDOM_COUNTER=0
+
+              log() {
+                echo "[$(date -u)] $*"
+              }
+
+              write_state() {
+                printf '%s\n' "$1" > "$STATE_FILE"
+              }
+
+              next_random() {
+                if [ -n "$BEHAVIOR_SEED" ]; then
+                  value=$(awk -v seed="$BEHAVIOR_SEED" -v step="$RANDOM_COUNTER" 'BEGIN { srand(seed + step); printf "%d\n", int(rand() * 32768) }')
+                else
+                  value=$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')
+                fi
+                RANDOM_COUNTER=$((RANDOM_COUNTER + 1))
+                printf '%s\n' "${value:-0}"
+              }
+
+              choose_behavior() {
+                set -- $BEHAVIOR_CHOICES
+                count=$#
+                if [ "$count" -eq 0 ]; then
+                  printf 'ok\n'
+                  return
+                fi
+                rand=$(next_random)
+                idx=$((rand % count + 1))
+                i=1
+                for option in "$@"; do
+                  if [ "$i" -eq "$idx" ]; then
+                    printf '%s\n' "$option"
+                    return
+                  fi
+                  i=$((i + 1))
                 done
-              else
-                while true; do
-                  echo "[$(date -u)] running normally (BEHAVIOR=$BEHAVIOR)"
-                  sleep 30
+                printf '%s\n' "$1"
+              }
+
+              random_minutes() {
+                rand=$(next_random)
+                printf '%s\n' $((rand % 60 + 1))
+              }
+
+              wait_duration() {
+                duration_seconds=$1
+                behavior_label=$2
+                end=$(( $(date +%s) + duration_seconds ))
+                while [ "$(date +%s)" -lt "$end" ]; do
+                  case "$behavior_label" in
+                    ok)
+                      log "running normally (dynamic ok)"
+                      sleep 30
+                      ;;
+                    notready)
+                      sleep 30
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
                 done
+              }
+
+              log "starting with BEHAVIOR=$BEHAVIOR"
+              write_state "$BEHAVIOR"
+
+              if [ "$BEHAVIOR" != "dynamic" ]; then
+                case "$BEHAVIOR" in
+                  restart)
+                    sleep 60
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    while true; do
+                      sleep 30
+                    done
+                    ;;
+                  *)
+                    while true; do
+                      log "running normally (BEHAVIOR=$BEHAVIOR)"
+                      sleep 30
+                    done
+                    ;;
+                esac
               fi
+
+              log "enabling dynamic behavior changes"
+              while true; do
+                next=$(choose_behavior)
+                minutes=$(random_minutes)
+                seconds=$((minutes * 60))
+                write_state "$next"
+                case "$next" in
+                  restart)
+                    log "switching to restart behavior for ${minutes} minute(s)"
+                    sleep "$seconds"
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    log "switching to notready behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                  *)
+                    log "switching to ok behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                esac
+              done
           livenessProbe:
             exec:
               command:
@@ -64,7 +167,12 @@ spec:
                 - sh
                 - -c
                 - |
-                  if [ "$BEHAVIOR" = "notready" ]; then
+                  STATE_FILE="/tmp/current_behavior"
+                  current="$BEHAVIOR"
+                  if [ -f "$STATE_FILE" ]; then
+                    current=$(cat "$STATE_FILE" 2>/dev/null || echo "$current")
+                  fi
+                  if [ "$current" = "notready" ]; then
                     exit 1
                   else
                     exit 0
@@ -102,26 +210,129 @@ spec:
           image: registry.access.redhat.com/ubi10/ubi-minimal
           env:
             - name: BEHAVIOR
-              value: "ok"
+              value: "dynamic"
+            - name: BEHAVIOR_SEED
+              value: "1646180181"
           command:
             - sh
             - -c
             - |
-              echo "[$(date -u)] starting with BEHAVIOR=$BEHAVIOR"
-              if [ "$BEHAVIOR" = "restart" ]; then
-                sleep 60
-                echo "[$(date -u)] simulating crash to trigger restart"
-                exit 1
-              elif [ "$BEHAVIOR" = "notready" ]; then
-                while true; do
-                  sleep 30
+              STATE_FILE="/tmp/current_behavior"
+              BEHAVIOR=${BEHAVIOR:-dynamic}
+              BEHAVIOR_SEED=${BEHAVIOR_SEED:-}
+              BEHAVIOR_CHOICES="ok notready restart"
+              RANDOM_COUNTER=0
+
+              log() {
+                echo "[$(date -u)] $*"
+              }
+
+              write_state() {
+                printf '%s\n' "$1" > "$STATE_FILE"
+              }
+
+              next_random() {
+                if [ -n "$BEHAVIOR_SEED" ]; then
+                  value=$(awk -v seed="$BEHAVIOR_SEED" -v step="$RANDOM_COUNTER" 'BEGIN { srand(seed + step); printf "%d\n", int(rand() * 32768) }')
+                else
+                  value=$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')
+                fi
+                RANDOM_COUNTER=$((RANDOM_COUNTER + 1))
+                printf '%s\n' "${value:-0}"
+              }
+
+              choose_behavior() {
+                set -- $BEHAVIOR_CHOICES
+                count=$#
+                if [ "$count" -eq 0 ]; then
+                  printf 'ok\n'
+                  return
+                fi
+                rand=$(next_random)
+                idx=$((rand % count + 1))
+                i=1
+                for option in "$@"; do
+                  if [ "$i" -eq "$idx" ]; then
+                    printf '%s\n' "$option"
+                    return
+                  fi
+                  i=$((i + 1))
                 done
-              else
-                while true; do
-                  echo "[$(date -u)] running normally (BEHAVIOR=$BEHAVIOR)"
-                  sleep 30
+                printf '%s\n' "$1"
+              }
+
+              random_minutes() {
+                rand=$(next_random)
+                printf '%s\n' $((rand % 60 + 1))
+              }
+
+              wait_duration() {
+                duration_seconds=$1
+                behavior_label=$2
+                end=$(( $(date +%s) + duration_seconds ))
+                while [ "$(date +%s)" -lt "$end" ]; do
+                  case "$behavior_label" in
+                    ok)
+                      log "running normally (dynamic ok)"
+                      sleep 30
+                      ;;
+                    notready)
+                      sleep 30
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
                 done
+              }
+
+              log "starting with BEHAVIOR=$BEHAVIOR"
+              write_state "$BEHAVIOR"
+
+              if [ "$BEHAVIOR" != "dynamic" ]; then
+                case "$BEHAVIOR" in
+                  restart)
+                    sleep 60
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    while true; do
+                      sleep 30
+                    done
+                    ;;
+                  *)
+                    while true; do
+                      log "running normally (BEHAVIOR=$BEHAVIOR)"
+                      sleep 30
+                    done
+                    ;;
+                esac
               fi
+
+              log "enabling dynamic behavior changes"
+              while true; do
+                next=$(choose_behavior)
+                minutes=$(random_minutes)
+                seconds=$((minutes * 60))
+                write_state "$next"
+                case "$next" in
+                  restart)
+                    log "switching to restart behavior for ${minutes} minute(s)"
+                    sleep "$seconds"
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    log "switching to notready behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                  *)
+                    log "switching to ok behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                esac
+              done
           livenessProbe:
             exec:
               command:
@@ -136,7 +347,192 @@ spec:
                 - sh
                 - -c
                 - |
-                  if [ "$BEHAVIOR" = "notready" ]; then
+                  STATE_FILE="/tmp/current_behavior"
+                  current="$BEHAVIOR"
+                  if [ -f "$STATE_FILE" ]; then
+                    current=$(cat "$STATE_FILE" 2>/dev/null || echo "$current")
+                  fi
+                  if [ "$current" = "notready" ]; then
+                    exit 1
+                  else
+                    exit 0
+                  fi
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: person-identity-availability-sim-3
+  namespace: business-domain
+  labels:
+    app: person-identity-availability-sim-3
+    arkit8s.simulator: "true"
+  annotations:
+    architecture.domain: business
+    architecture.function: person-identity-load-simulator
+    architecture.simulates: person-identity-verification-app-instance
+    architecture.part_of: arkit8s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: person-identity-availability-sim-3
+  template:
+    metadata:
+      labels:
+        app: person-identity-availability-sim-3
+        arkit8s.simulator: "true"
+        arkit8s.simulates: person-identity-verification-app-instance
+    spec:
+      containers:
+        - name: availability-simulator
+          image: registry.access.redhat.com/ubi10/ubi-minimal
+          env:
+            - name: BEHAVIOR
+              value: "dynamic"
+            - name: BEHAVIOR_SEED
+              value: "689036458"
+          command:
+            - sh
+            - -c
+            - |
+              STATE_FILE="/tmp/current_behavior"
+              BEHAVIOR=${BEHAVIOR:-dynamic}
+              BEHAVIOR_SEED=${BEHAVIOR_SEED:-}
+              BEHAVIOR_CHOICES="ok notready restart"
+              RANDOM_COUNTER=0
+
+              log() {
+                echo "[$(date -u)] $*"
+              }
+
+              write_state() {
+                printf '%s\n' "$1" > "$STATE_FILE"
+              }
+
+              next_random() {
+                if [ -n "$BEHAVIOR_SEED" ]; then
+                  value=$(awk -v seed="$BEHAVIOR_SEED" -v step="$RANDOM_COUNTER" 'BEGIN { srand(seed + step); printf "%d\n", int(rand() * 32768) }')
+                else
+                  value=$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')
+                fi
+                RANDOM_COUNTER=$((RANDOM_COUNTER + 1))
+                printf '%s\n' "${value:-0}"
+              }
+
+              choose_behavior() {
+                set -- $BEHAVIOR_CHOICES
+                count=$#
+                if [ "$count" -eq 0 ]; then
+                  printf 'ok\n'
+                  return
+                fi
+                rand=$(next_random)
+                idx=$((rand % count + 1))
+                i=1
+                for option in "$@"; do
+                  if [ "$i" -eq "$idx" ]; then
+                    printf '%s\n' "$option"
+                    return
+                  fi
+                  i=$((i + 1))
+                done
+                printf '%s\n' "$1"
+              }
+
+              random_minutes() {
+                rand=$(next_random)
+                printf '%s\n' $((rand % 60 + 1))
+              }
+
+              wait_duration() {
+                duration_seconds=$1
+                behavior_label=$2
+                end=$(( $(date +%s) + duration_seconds ))
+                while [ "$(date +%s)" -lt "$end" ]; do
+                  case "$behavior_label" in
+                    ok)
+                      log "running normally (dynamic ok)"
+                      sleep 30
+                      ;;
+                    notready)
+                      sleep 30
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
+                done
+              }
+
+              log "starting with BEHAVIOR=$BEHAVIOR"
+              write_state "$BEHAVIOR"
+
+              if [ "$BEHAVIOR" != "dynamic" ]; then
+                case "$BEHAVIOR" in
+                  restart)
+                    sleep 60
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    while true; do
+                      sleep 30
+                    done
+                    ;;
+                  *)
+                    while true; do
+                      log "running normally (BEHAVIOR=$BEHAVIOR)"
+                      sleep 30
+                    done
+                    ;;
+                esac
+              fi
+
+              log "enabling dynamic behavior changes"
+              while true; do
+                next=$(choose_behavior)
+                minutes=$(random_minutes)
+                seconds=$((minutes * 60))
+                write_state "$next"
+                case "$next" in
+                  restart)
+                    log "switching to restart behavior for ${minutes} minute(s)"
+                    sleep "$seconds"
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    log "switching to notready behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                  *)
+                    log "switching to ok behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                esac
+              done
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exit 0
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  STATE_FILE="/tmp/current_behavior"
+                  current="$BEHAVIOR"
+                  if [ -f "$STATE_FILE" ]; then
+                    current=$(cat "$STATE_FILE" 2>/dev/null || echo "$current")
+                  fi
+                  if [ "$current" = "notready" ]; then
                     exit 1
                   else
                     exit 0

--- a/architecture/business-domain/ui/load-simulators.yaml
+++ b/architecture/business-domain/ui/load-simulators.yaml
@@ -30,26 +30,129 @@ spec:
           image: registry.access.redhat.com/ubi10/ubi-minimal
           env:
             - name: BEHAVIOR
-              value: "ok"
+              value: "dynamic"
+            - name: BEHAVIOR_SEED
+              value: "1436542229"
           command:
             - sh
             - -c
             - |
-              echo "[$(date -u)] starting with BEHAVIOR=$BEHAVIOR"
-              if [ "$BEHAVIOR" = "restart" ]; then
-                sleep 60
-                echo "[$(date -u)] simulating crash to trigger restart"
-                exit 1
-              elif [ "$BEHAVIOR" = "notready" ]; then
-                while true; do
-                  sleep 30
+              STATE_FILE="/tmp/current_behavior"
+              BEHAVIOR=${BEHAVIOR:-dynamic}
+              BEHAVIOR_SEED=${BEHAVIOR_SEED:-}
+              BEHAVIOR_CHOICES="ok notready restart"
+              RANDOM_COUNTER=0
+
+              log() {
+                echo "[$(date -u)] $*"
+              }
+
+              write_state() {
+                printf '%s\n' "$1" > "$STATE_FILE"
+              }
+
+              next_random() {
+                if [ -n "$BEHAVIOR_SEED" ]; then
+                  value=$(awk -v seed="$BEHAVIOR_SEED" -v step="$RANDOM_COUNTER" 'BEGIN { srand(seed + step); printf "%d\n", int(rand() * 32768) }')
+                else
+                  value=$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')
+                fi
+                RANDOM_COUNTER=$((RANDOM_COUNTER + 1))
+                printf '%s\n' "${value:-0}"
+              }
+
+              choose_behavior() {
+                set -- $BEHAVIOR_CHOICES
+                count=$#
+                if [ "$count" -eq 0 ]; then
+                  printf 'ok\n'
+                  return
+                fi
+                rand=$(next_random)
+                idx=$((rand % count + 1))
+                i=1
+                for option in "$@"; do
+                  if [ "$i" -eq "$idx" ]; then
+                    printf '%s\n' "$option"
+                    return
+                  fi
+                  i=$((i + 1))
                 done
-              else
-                while true; do
-                  echo "[$(date -u)] running normally (BEHAVIOR=$BEHAVIOR)"
-                  sleep 30
+                printf '%s\n' "$1"
+              }
+
+              random_minutes() {
+                rand=$(next_random)
+                printf '%s\n' $((rand % 60 + 1))
+              }
+
+              wait_duration() {
+                duration_seconds=$1
+                behavior_label=$2
+                end=$(( $(date +%s) + duration_seconds ))
+                while [ "$(date +%s)" -lt "$end" ]; do
+                  case "$behavior_label" in
+                    ok)
+                      log "running normally (dynamic ok)"
+                      sleep 30
+                      ;;
+                    notready)
+                      sleep 30
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
                 done
+              }
+
+              log "starting with BEHAVIOR=$BEHAVIOR"
+              write_state "$BEHAVIOR"
+
+              if [ "$BEHAVIOR" != "dynamic" ]; then
+                case "$BEHAVIOR" in
+                  restart)
+                    sleep 60
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    while true; do
+                      sleep 30
+                    done
+                    ;;
+                  *)
+                    while true; do
+                      log "running normally (BEHAVIOR=$BEHAVIOR)"
+                      sleep 30
+                    done
+                    ;;
+                esac
               fi
+
+              log "enabling dynamic behavior changes"
+              while true; do
+                next=$(choose_behavior)
+                minutes=$(random_minutes)
+                seconds=$((minutes * 60))
+                write_state "$next"
+                case "$next" in
+                  restart)
+                    log "switching to restart behavior for ${minutes} minute(s)"
+                    sleep "$seconds"
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    log "switching to notready behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                  *)
+                    log "switching to ok behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                esac
+              done
           livenessProbe:
             exec:
               command:
@@ -64,7 +167,12 @@ spec:
                 - sh
                 - -c
                 - |
-                  if [ "$BEHAVIOR" = "notready" ]; then
+                  STATE_FILE="/tmp/current_behavior"
+                  current="$BEHAVIOR"
+                  if [ -f "$STATE_FILE" ]; then
+                    current=$(cat "$STATE_FILE" 2>/dev/null || echo "$current")
+                  fi
+                  if [ "$current" = "notready" ]; then
                     exit 1
                   else
                     exit 0
@@ -102,26 +210,129 @@ spec:
           image: registry.access.redhat.com/ubi10/ubi-minimal
           env:
             - name: BEHAVIOR
-              value: "ok"
+              value: "dynamic"
+            - name: BEHAVIOR_SEED
+              value: "2008113661"
           command:
             - sh
             - -c
             - |
-              echo "[$(date -u)] starting with BEHAVIOR=$BEHAVIOR"
-              if [ "$BEHAVIOR" = "restart" ]; then
-                sleep 60
-                echo "[$(date -u)] simulating crash to trigger restart"
-                exit 1
-              elif [ "$BEHAVIOR" = "notready" ]; then
-                while true; do
-                  sleep 30
+              STATE_FILE="/tmp/current_behavior"
+              BEHAVIOR=${BEHAVIOR:-dynamic}
+              BEHAVIOR_SEED=${BEHAVIOR_SEED:-}
+              BEHAVIOR_CHOICES="ok notready restart"
+              RANDOM_COUNTER=0
+
+              log() {
+                echo "[$(date -u)] $*"
+              }
+
+              write_state() {
+                printf '%s\n' "$1" > "$STATE_FILE"
+              }
+
+              next_random() {
+                if [ -n "$BEHAVIOR_SEED" ]; then
+                  value=$(awk -v seed="$BEHAVIOR_SEED" -v step="$RANDOM_COUNTER" 'BEGIN { srand(seed + step); printf "%d\n", int(rand() * 32768) }')
+                else
+                  value=$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')
+                fi
+                RANDOM_COUNTER=$((RANDOM_COUNTER + 1))
+                printf '%s\n' "${value:-0}"
+              }
+
+              choose_behavior() {
+                set -- $BEHAVIOR_CHOICES
+                count=$#
+                if [ "$count" -eq 0 ]; then
+                  printf 'ok\n'
+                  return
+                fi
+                rand=$(next_random)
+                idx=$((rand % count + 1))
+                i=1
+                for option in "$@"; do
+                  if [ "$i" -eq "$idx" ]; then
+                    printf '%s\n' "$option"
+                    return
+                  fi
+                  i=$((i + 1))
                 done
-              else
-                while true; do
-                  echo "[$(date -u)] running normally (BEHAVIOR=$BEHAVIOR)"
-                  sleep 30
+                printf '%s\n' "$1"
+              }
+
+              random_minutes() {
+                rand=$(next_random)
+                printf '%s\n' $((rand % 60 + 1))
+              }
+
+              wait_duration() {
+                duration_seconds=$1
+                behavior_label=$2
+                end=$(( $(date +%s) + duration_seconds ))
+                while [ "$(date +%s)" -lt "$end" ]; do
+                  case "$behavior_label" in
+                    ok)
+                      log "running normally (dynamic ok)"
+                      sleep 30
+                      ;;
+                    notready)
+                      sleep 30
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
                 done
+              }
+
+              log "starting with BEHAVIOR=$BEHAVIOR"
+              write_state "$BEHAVIOR"
+
+              if [ "$BEHAVIOR" != "dynamic" ]; then
+                case "$BEHAVIOR" in
+                  restart)
+                    sleep 60
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    while true; do
+                      sleep 30
+                    done
+                    ;;
+                  *)
+                    while true; do
+                      log "running normally (BEHAVIOR=$BEHAVIOR)"
+                      sleep 30
+                    done
+                    ;;
+                esac
               fi
+
+              log "enabling dynamic behavior changes"
+              while true; do
+                next=$(choose_behavior)
+                minutes=$(random_minutes)
+                seconds=$((minutes * 60))
+                write_state "$next"
+                case "$next" in
+                  restart)
+                    log "switching to restart behavior for ${minutes} minute(s)"
+                    sleep "$seconds"
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    log "switching to notready behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                  *)
+                    log "switching to ok behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                esac
+              done
           livenessProbe:
             exec:
               command:
@@ -136,7 +347,192 @@ spec:
                 - sh
                 - -c
                 - |
-                  if [ "$BEHAVIOR" = "notready" ]; then
+                  STATE_FILE="/tmp/current_behavior"
+                  current="$BEHAVIOR"
+                  if [ -f "$STATE_FILE" ]; then
+                    current=$(cat "$STATE_FILE" 2>/dev/null || echo "$current")
+                  fi
+                  if [ "$current" = "notready" ]; then
+                    exit 1
+                  else
+                    exit 0
+                  fi
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ui-availability-sim-3
+  namespace: business-domain
+  labels:
+    app: ui-availability-sim-3
+    arkit8s.simulator: "true"
+  annotations:
+    architecture.domain: business
+    architecture.function: ui-load-simulator
+    architecture.simulates: ui-app-instance
+    architecture.part_of: arkit8s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ui-availability-sim-3
+  template:
+    metadata:
+      labels:
+        app: ui-availability-sim-3
+        arkit8s.simulator: "true"
+        arkit8s.simulates: ui-app-instance
+    spec:
+      containers:
+        - name: availability-simulator
+          image: registry.access.redhat.com/ubi10/ubi-minimal
+          env:
+            - name: BEHAVIOR
+              value: "dynamic"
+            - name: BEHAVIOR_SEED
+              value: "144860314"
+          command:
+            - sh
+            - -c
+            - |
+              STATE_FILE="/tmp/current_behavior"
+              BEHAVIOR=${BEHAVIOR:-dynamic}
+              BEHAVIOR_SEED=${BEHAVIOR_SEED:-}
+              BEHAVIOR_CHOICES="ok notready restart"
+              RANDOM_COUNTER=0
+
+              log() {
+                echo "[$(date -u)] $*"
+              }
+
+              write_state() {
+                printf '%s\n' "$1" > "$STATE_FILE"
+              }
+
+              next_random() {
+                if [ -n "$BEHAVIOR_SEED" ]; then
+                  value=$(awk -v seed="$BEHAVIOR_SEED" -v step="$RANDOM_COUNTER" 'BEGIN { srand(seed + step); printf "%d\n", int(rand() * 32768) }')
+                else
+                  value=$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')
+                fi
+                RANDOM_COUNTER=$((RANDOM_COUNTER + 1))
+                printf '%s\n' "${value:-0}"
+              }
+
+              choose_behavior() {
+                set -- $BEHAVIOR_CHOICES
+                count=$#
+                if [ "$count" -eq 0 ]; then
+                  printf 'ok\n'
+                  return
+                fi
+                rand=$(next_random)
+                idx=$((rand % count + 1))
+                i=1
+                for option in "$@"; do
+                  if [ "$i" -eq "$idx" ]; then
+                    printf '%s\n' "$option"
+                    return
+                  fi
+                  i=$((i + 1))
+                done
+                printf '%s\n' "$1"
+              }
+
+              random_minutes() {
+                rand=$(next_random)
+                printf '%s\n' $((rand % 60 + 1))
+              }
+
+              wait_duration() {
+                duration_seconds=$1
+                behavior_label=$2
+                end=$(( $(date +%s) + duration_seconds ))
+                while [ "$(date +%s)" -lt "$end" ]; do
+                  case "$behavior_label" in
+                    ok)
+                      log "running normally (dynamic ok)"
+                      sleep 30
+                      ;;
+                    notready)
+                      sleep 30
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
+                done
+              }
+
+              log "starting with BEHAVIOR=$BEHAVIOR"
+              write_state "$BEHAVIOR"
+
+              if [ "$BEHAVIOR" != "dynamic" ]; then
+                case "$BEHAVIOR" in
+                  restart)
+                    sleep 60
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    while true; do
+                      sleep 30
+                    done
+                    ;;
+                  *)
+                    while true; do
+                      log "running normally (BEHAVIOR=$BEHAVIOR)"
+                      sleep 30
+                    done
+                    ;;
+                esac
+              fi
+
+              log "enabling dynamic behavior changes"
+              while true; do
+                next=$(choose_behavior)
+                minutes=$(random_minutes)
+                seconds=$((minutes * 60))
+                write_state "$next"
+                case "$next" in
+                  restart)
+                    log "switching to restart behavior for ${minutes} minute(s)"
+                    sleep "$seconds"
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    log "switching to notready behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                  *)
+                    log "switching to ok behavior for ${minutes} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                esac
+              done
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exit 0
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  STATE_FILE="/tmp/current_behavior"
+                  current="$BEHAVIOR"
+                  if [ -f "$STATE_FILE" ]; then
+                    current=$(cat "$STATE_FILE" 2>/dev/null || echo "$current")
+                  fi
+                  if [ "$current" = "notready" ]; then
                     exit 1
                   else
                     exit 0

--- a/utilities/simulator-deployment.yaml.tpl
+++ b/utilities/simulator-deployment.yaml.tpl
@@ -29,25 +29,128 @@ spec:
           env:
             - name: BEHAVIOR
               value: "{behavior}"
+            - name: BEHAVIOR_SEED
+              value: "{behavior_seed}"
           command:
             - sh
             - -c
             - |
-              echo "[$(date -u)] starting with BEHAVIOR=$BEHAVIOR"
-              if [ "$BEHAVIOR" = "restart" ]; then
-                sleep 60
-                echo "[$(date -u)] simulating crash to trigger restart"
-                exit 1
-              elif [ "$BEHAVIOR" = "notready" ]; then
-                while true; do
-                  sleep 30
+              STATE_FILE="/tmp/current_behavior"
+              BEHAVIOR=${{BEHAVIOR:-dynamic}}
+              BEHAVIOR_SEED=${{BEHAVIOR_SEED:-}}
+              BEHAVIOR_CHOICES="ok notready restart"
+              RANDOM_COUNTER=0
+
+              log() {{
+                echo "[$(date -u)] $*"
+              }}
+
+              write_state() {{
+                printf '%s\n' "$1" > "$STATE_FILE"
+              }}
+
+              next_random() {{
+                if [ -n "$BEHAVIOR_SEED" ]; then
+                  value=$(awk -v seed="$BEHAVIOR_SEED" -v step="$RANDOM_COUNTER" 'BEGIN {{ srand(seed + step); printf "%d\n", int(rand() * 32768) }}')
+                else
+                  value=$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')
+                fi
+                RANDOM_COUNTER=$((RANDOM_COUNTER + 1))
+                printf '%s\n' "${{value:-0}}"
+              }}
+
+              choose_behavior() {{
+                set -- $BEHAVIOR_CHOICES
+                count=$#
+                if [ "$count" -eq 0 ]; then
+                  printf 'ok\n'
+                  return
+                fi
+                rand=$(next_random)
+                idx=$((rand % count + 1))
+                i=1
+                for option in "$@"; do
+                  if [ "$i" -eq "$idx" ]; then
+                    printf '%s\n' "$option"
+                    return
+                  fi
+                  i=$((i + 1))
                 done
-              else
-                while true; do
-                  echo "[$(date -u)] running normally (BEHAVIOR=$BEHAVIOR)"
-                  sleep 30
+                printf '%s\n' "$1"
+              }}
+
+              random_minutes() {{
+                rand=$(next_random)
+                printf '%s\n' $((rand % 60 + 1))
+              }}
+
+              wait_duration() {{
+                duration_seconds=$1
+                behavior_label=$2
+                end=$(( $(date +%s) + duration_seconds ))
+                while [ "$(date +%s)" -lt "$end" ]; do
+                  case "$behavior_label" in
+                    ok)
+                      log "running normally (dynamic ok)"
+                      sleep 30
+                      ;;
+                    notready)
+                      sleep 30
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
                 done
+              }}
+
+              log "starting with BEHAVIOR=$BEHAVIOR"
+              write_state "$BEHAVIOR"
+
+              if [ "$BEHAVIOR" != "dynamic" ]; then
+                case "$BEHAVIOR" in
+                  restart)
+                    sleep 60
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    while true; do
+                      sleep 30
+                    done
+                    ;;
+                  *)
+                    while true; do
+                      log "running normally (BEHAVIOR=$BEHAVIOR)"
+                      sleep 30
+                    done
+                    ;;
+                esac
               fi
+
+              log "enabling dynamic behavior changes"
+              while true; do
+                next=$(choose_behavior)
+                minutes=$(random_minutes)
+                seconds=$((minutes * 60))
+                write_state "$next"
+                case "$next" in
+                  restart)
+                    log "switching to restart behavior for ${{minutes}} minute(s)"
+                    sleep "$seconds"
+                    log "simulating crash to trigger restart"
+                    exit 1
+                    ;;
+                  notready)
+                    log "switching to notready behavior for ${{minutes}} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                  *)
+                    log "switching to ok behavior for ${{minutes}} minute(s)"
+                    wait_duration "$seconds" "$next"
+                    ;;
+                esac
+              done
           livenessProbe:
             exec:
               command:
@@ -62,7 +165,12 @@ spec:
                 - sh
                 - -c
                 - |
-                  if [ "$BEHAVIOR" = "notready" ]; then
+                  STATE_FILE="/tmp/current_behavior"
+                  current="$BEHAVIOR"
+                  if [ -f "$STATE_FILE" ]; then
+                    current=$(cat "$STATE_FILE" 2>/dev/null || echo "$current")
+                  fi
+                  if [ "$current" = "notready" ]; then
                     exit 1
                   else
                     exit 0


### PR DESCRIPTION
## Summary
- allow `generate-load-simulators` to accept an explicit `--behavior` override while defaulting to dynamic changes
- extend the simulator command script to rotate behaviors on random 1-60 minute intervals using deterministic seeds when provided
- refresh generated load-simulator manifests and update documentation with usage examples

## Testing
- python3 -m compileall arkit8s.py

------
https://chatgpt.com/codex/tasks/task_e_68e5d586b8a4833398ad9cdf3d01a2aa