### PR TITLE
Add one-command default scenario install and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ El script `arkit8s.py` centraliza las tareas operativas de la plataforma. Todos 
 - `install [--env <nombre>]` – aplica los manifiestos base (`architecture/bootstrap`) y los del entorno indicado en `environments/`, verificando que existan los namespaces esperados y las ServiceAccounts que habilitan componentes como Sentik.
 - `uninstall` – elimina los recursos definidos en `architecture/` (incluyendo bootstrap). No falla si los recursos ya no existen.
 - `cleanup [--env <nombre>]` – borra todos los recursos del entorno indicado, incluidos los namespaces creados por `bootstrap`, dejando el clúster listo para una instalación desde cero.
+- `install-default [--simulators <n>] [--seed <n>]` – despliega el entorno `sandbox` y genera 10 simuladores de carga aleatorios (configurable con `--simulators`) etiquetados como parte del escenario por defecto.
+- `cleanup-default` – elimina los simuladores del escenario por defecto y limpia por completo el entorno `sandbox`.
 - `validate-cluster [--env <nombre>]` – revisa namespaces, deployments, pods y sincronización (`oc diff`) para asegurar que el estado del clúster coincide con los manifiestos.
 - `watch [--env <nombre>] [--minutes <n>] [--detail <default|detailed|all>]` – ejecuta validaciones continuas cada 30 segundos durante el tiempo indicado. Con `--detail` distinto de `default` imprime el inventario de recursos monitoreados.
 - `validate-yaml` – recorre el repositorio y verifica que todos los YAML (excepto `kustomization.yaml`) sean sintácticamente válidos.
@@ -73,6 +75,8 @@ El script `arkit8s.py` centraliza las tareas operativas de la plataforma. Todos 
 - `./arkit8s.py generate-load-simulators --behavior notready` – todos los simuladores permanecen permanentemente en estado `notready`, útil para probar alertas de disponibilidad.
 - `./arkit8s.py generate-load-simulators --behavior ok` – los simuladores se mantienen estables y siempre listos, ideal para validar flujos felices sin interrupciones.
 - `./arkit8s.py generate-load-simulators --behavior restart` – los simuladores reinician periódicamente tras 60 segundos, ideal para evaluar tolerancia a reinicios.
+- `./arkit8s.py install-default --simulators 15` – despliega el escenario por defecto con 15 simuladores distribuidos aleatoriamente entre los componentes disponibles.
+- `./arkit8s.py cleanup-default` – limpia por completo el escenario por defecto junto al entorno `sandbox`.
 
 ### Ejemplo práctico: instalar **Sentik**
 


### PR DESCRIPTION
## Summary
- add CLI commands to install or clean up the default sandbox scenario with random simulators
- generate and apply ten labeled simulator deployments using the shared template and new helpers
- document the new workflow in the README help block for quick reference

## Testing
- python -m compileall arkit8s.py

------
https://chatgpt.com/codex/tasks/task_e_68e66559d02c8333a28915a1b8c5b9ca